### PR TITLE
Optimize `GitHubActionsRunner` initialization

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.14.0
+current_version = 0.14.1
 commit = True
 
 [bumpversion:file:pyproject.toml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "infrahouse-core"
-version = "0.14.0"
+version = "0.14.1"
 description = "Lightweight Python library with AWS and other general purpose classes."
 readme = "README.rst"
 requires-python = ">=3.10"

--- a/src/infrahouse_core/__init__.py
+++ b/src/infrahouse_core/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Oleksandr Kuzminskyi"""
 __email__ = "aleks@infrahouse.com"
-__version__ = "0.14.0"
+__version__ = "0.14.1"


### PR DESCRIPTION
When `GitHubActions` pulls a list of runners, it already has access to
the runners data. Then, it can pass it to `GitHubActionsRunner` to save
on further API calls.
