### PR TITLE
Don't cache runners

### DIFF
--- a/src/infrahouse_core/github.py
+++ b/src/infrahouse_core/github.py
@@ -177,7 +177,6 @@ class GitHubActions:
         :type github: GitHubAuth
         """
         self._github = github
-        self._runners = None
 
     @property
     def registration_token(self) -> str:
@@ -203,12 +202,7 @@ class GitHubActions:
         :return: A list of GitHubActionsRunner objects.
         :rtype: list[GitHubActionsRunner]
         """
-        if self._runners is None:
-            self._runners = [
-                GitHubActionsRunner(r["id"], self._github, runner_data=r) for r in self._get_github_runners()
-            ]
-
-        return self._runners
+        return [GitHubActionsRunner(r["id"], self._github, runner_data=r) for r in self._get_github_runners()]
 
     def deregister_runner(self, runner: GitHubActionsRunner):
         """


### PR DESCRIPTION
Runners is a dynamic list, they come and go. Therefore, a list of runners should be retrieved every time.
I don't expect this might case problems with overwhelming GitHub API, but if that proves to be a case, I will cache the runners property with a TTL.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove caching of GitHub Actions runners by eliminating the `_runners` attribute and directly returning a fresh list of runners each time the `runners` property is accessed.

### Why are these changes being made?

This change addresses potential issues related to stale data and memory overhead by fetching the latest state of runners whenever they are accessed, ensuring the information is always up-to-date and reflecting the current environment state. While this may result in slightly increased computational cost due to repeated data fetching, it ensures accuracy and consistency in environments where runners' states frequently change.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->