### PR TITLE
Fix SSO login when SSO region differs from profile region

### DIFF
--- a/src/infrahouse_core/aws/__init__.py
+++ b/src/infrahouse_core/aws/__init__.py
@@ -354,7 +354,7 @@ def _get_credentials(aws_config: AWSConfig, profile_name: str):
     """
 
     session = Session()
-    sso_oidc = session.client("sso-oidc")
+    sso_oidc = session.client("sso-oidc", aws_config.get_sso_region(profile_name))
 
     try:
         client_creds = sso_oidc.register_client(
@@ -399,7 +399,7 @@ def _get_credentials(aws_config: AWSConfig, profile_name: str):
                 clientId=client_creds["clientId"],
                 clientSecret=client_creds["clientSecret"],
             )
-            return session.client("sso").get_role_credentials(
+            return session.client("sso", region_name=aws_config.get_sso_region(profile_name)).get_role_credentials(
                 roleName=aws_config.get_role(profile_name),
                 accountId=aws_config.get_account_id(profile_name),
                 accessToken=token["accessToken"],

--- a/src/infrahouse_core/aws/config.py
+++ b/src/infrahouse_core/aws/config.py
@@ -91,6 +91,21 @@ class AWSConfig:
         except NoOptionError:
             return self.config_parser.get("default", "region") if "default" in self.config_parser.sections() else None
 
+    def get_sso_region(self, profile_name):
+        """For a given profile, find SSO region"""
+        try:
+            sso_session = self.config_parser.get(self._get_section(profile_name), "sso_session")
+        except NoOptionError:
+            return self.config_parser.get("default", "region") if "default" in self.config_parser.sections() else None
+
+        except NoSectionError:
+            return self.config_parser.get("default", "region") if "default" in self.config_parser.sections() else None
+
+        try:
+            return self.config_parser.get(f"sso-session {sso_session}", "sso_region")
+        except NoOptionError:
+            return self.config_parser.get("default", "region")
+
     def get_role(self, profile_name):
         """Read AWS IAM role for given profile."""
         return self.config_parser.get(self._get_section(profile_name), "sso_role_name")

--- a/tests/aws/config/test_get_sso_region.py
+++ b/tests/aws/config/test_get_sso_region.py
@@ -1,0 +1,62 @@
+from textwrap import dedent
+
+import pytest
+
+from infrahouse_core.aws import AWSConfig
+
+CONTENT = dedent(
+    """
+    [default]
+    region = us-west-123
+
+    [sso-session foo_session]
+    sso_start_url = https://foo.com/start#
+    sso_region = us-west-1
+    sso_registration_scopes = sso:account:access
+
+    [profile foo_profile]
+    sso_session = foo_session
+    sso_account_id = 12345678
+    sso_role_name = admin
+    region = us-west-2
+
+    [sso-session bar_session]
+    sso_start_url = https://bar.com/start#
+    sso_registration_scopes = sso:account:access
+
+    [profile bar_profile]
+    sso_session = bar_session
+    sso_account_id = 12345678
+    sso_role_name = admin
+    region = us-west-2
+    """
+)
+
+CONTENT_2 = dedent(
+    """
+    [profile foo]
+    region = us-west-345
+
+    [profile bar]
+    """
+)
+
+
+@pytest.mark.parametrize(
+    "profile, content, region",
+    [
+        ("foo_profile", CONTENT, "us-west-1"),
+        ("bar_profile", CONTENT, "us-west-123"),
+        (None, CONTENT, "us-west-123"),
+        ("default", CONTENT, "us-west-123"),
+        ("default", CONTENT_2, None),
+        ("foo", CONTENT_2, None),
+        ("bar", CONTENT_2, None),
+        (None, CONTENT_2, None),
+    ],
+)
+def test_sso_region(profile, region, content, tmpdir):
+    aws_home = tmpdir.mkdir("home")
+    cfg = aws_home.join("config")
+    cfg.write(content)
+    assert AWSConfig(aws_home=str(aws_home)).get_sso_region(profile) == region


### PR DESCRIPTION
  Pass the SSO region from the sso-session config section to the sso-oidc
  and sso clients during credential retrieval. Previously, the clients
  used the default region which caused failures when the SSO endpoint was
  in a different region than the profile's configured region.

  Ported from infrahouse/infrahouse-toolkit#162
