### PR TITLE
Add exists/delete interface to AWS resource classes

### DIFF
--- a/.claude/commands/review-local.md
+++ b/.claude/commands/review-local.md
@@ -1,0 +1,97 @@
+---
+description: Run Python module review locally (similar to GitHub PR review)
+---
+
+You are running a local Python module review, similar to the automated GitHub PR review workflow.
+
+## Your Task
+
+1. **Create review directory:**
+   ```bash
+   mkdir -p .claude/reviews
+   ```
+
+2. **Check for previous review:**
+   - Look for `.claude/reviews/python-module-review.md`
+   - If it exists, this is a follow-up review (read the existing file as the "previous" review)
+   - If it doesn't exist, this is the first review
+
+3. **Get changes to review:**
+   - First, check what changes exist:
+     ```bash
+     # Check for uncommitted changes
+     git status --short
+
+     # Check for commits ahead of main/master
+     git log --oneline origin/main..HEAD 2>/dev/null || git log --oneline origin/master..HEAD 2>/dev/null || echo "No remote branch found"
+     ```
+
+   - Based on what's found, create a diff file in .claude/reviews/:
+     - **If there are uncommitted changes:** `git diff HEAD > .claude/reviews/pr-changes.diff`
+     - **If there are committed changes ahead of main:** `git diff origin/main...HEAD > .claude/reviews/pr-changes.diff` (or origin/master)
+     - **If no changes:** Tell the user there's nothing to review
+
+4. **Show the user what will be reviewed:**
+   ```bash
+   echo "Changes to review:"
+   cat .claude/reviews/pr-changes.diff | head -50
+   echo ""
+   echo "Total lines in diff: $(wc -l < .claude/reviews/pr-changes.diff)"
+   ```
+
+5. **Launch the python-module-reviewer agent:**
+
+   **For FIRST review (no previous review found):**
+   ```
+   Launch the python-module-reviewer agent.
+
+   Review all changes in .claude/reviews/pr-changes.diff file.
+
+   Focus your review on the changes made while considering the overall module context.
+   Analyze what was added, modified, or removed, and assess the impact on:
+   - Security (credential handling, input validation, secret exposure)
+   - AWS integration patterns (boto3 best practices, error handling, pagination)
+   - Code quality (naming, docstrings, type hints, complexity)
+   - Testing (coverage, mocking, fixtures, error paths)
+   - Best practices compliance (Black, isort, pylint, PEP 8)
+
+   IMPORTANT: Save your complete review to .claude/reviews/python-module-review.md
+   as specified in your agent instructions.
+   ```
+
+   **For FOLLOW-UP review (previous review exists):**
+   ```
+   Launch the python-module-reviewer agent.
+
+   This is a follow-up review.
+
+   Read the previous review from .claude/reviews/python-module-review.md
+   and the current changes in .claude/reviews/pr-changes.diff.
+
+   Compare the previous findings with the current state:
+   - Mark issues as '✅ FIXED:' if they have been resolved
+   - Mark issues as '⚠️ STILL PRESENT:' if unaddressed
+   - Mark new issues as '🆕 NEW:' if they appear for the first time
+   - Provide a summary at the top showing progress
+     (e.g., '3 issues fixed, 1 still present, 2 new issues found')
+
+   Focus on showing what has improved and what still needs attention.
+
+   IMPORTANT: Overwrite .claude/reviews/python-module-review.md with your
+   new review (replacing the previous one) as specified in your agent instructions.
+   ```
+
+6. **After the agent completes:**
+   - Verify the review was created/updated: `ls -lh .claude/reviews/python-module-review.md`
+   - Show the user where to find it
+   - Let them know they can:
+     - Read the review now
+     - Make changes and run /review-local again to see what improved
+
+## Important Notes
+
+- This review runs **locally** - it won't post to GitHub
+- The review helps you catch issues **before** creating a PR
+- You can iterate: make changes → run /review-local again → see what improved
+- Each /review-local run overwrites the previous review (showing your progress)
+- When you're satisfied, create your PR and the GitHub workflow will do the official review

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,5 +60,7 @@ The library is organized into two main areas under `src/infrahouse_core/`:
 ### Key Patterns
 - Classes accept optional `role_arn` parameter to assume IAM roles for cross-account access
 - AWS clients are lazily created using `get_client()` helper with optional role assumption
+- All AWS resource classes implement an `exists` property and idempotent `delete()` method (see `base.AWSResource` for the interface contract)
+- `delete()` methods use try/except (EAFP), not check-then-act, to avoid TOCTOU race conditions
 - Properties use `cached_property_with_ttl` for time-limited caching of API responses
 - Tests use `unittest.mock` to patch AWS API calls

--- a/docs/infrahouse_core.aws.rst
+++ b/docs/infrahouse_core.aws.rst
@@ -12,6 +12,14 @@ Subpackages
 Submodules
 ----------
 
+infrahouse\_core.aws.base module
+--------------------------------
+
+.. automodule:: infrahouse_core.aws.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 infrahouse\_core.aws.asg module
 -------------------------------
 

--- a/src/infrahouse_core/aws/base.py
+++ b/src/infrahouse_core/aws/base.py
@@ -1,0 +1,63 @@
+"""
+Base class for AWS resource wrappers.
+
+Provides a standard interface (``exists`` property and ``delete()`` method)
+that all AWS resource classes should implement.
+"""
+
+from abc import ABC, abstractmethod
+from logging import getLogger
+
+from infrahouse_core.aws import get_client
+
+LOG = getLogger(__name__)
+
+
+class AWSResource(ABC):
+    """Abstract base class for AWS resource wrappers.
+
+    Subclasses must implement the :attr:`exists` property and the
+    :meth:`delete` method.  The constructor provides a lazy-loaded
+    boto3 client via :attr:`_client`.
+
+    :param resource_id: Primary identifier for the resource (ID, name, ARN, etc.).
+    :param service_name: AWS service name passed to ``get_client()``
+        (e.g. ``"ec2"``, ``"dynamodb"``).
+    :param region: AWS region.
+    :param role_arn: IAM role ARN for cross-account access.
+    """
+
+    def __init__(self, resource_id, service_name, region=None, role_arn=None):
+        self._resource_id = resource_id
+        self._service_name = service_name
+        self._region = region
+        self._role_arn = role_arn
+        self._client_instance = None
+
+    @property
+    def _client(self):
+        """Lazy-loaded boto3 client via :func:`get_client`."""
+        if self._client_instance is None:
+            self._client_instance = get_client(
+                self._service_name,
+                region=self._region,
+                role_arn=self._role_arn,
+            )
+            LOG.debug(
+                "Created %s client in %s region",
+                self._service_name,
+                self._client_instance.meta.region_name,
+            )
+        return self._client_instance
+
+    @property
+    @abstractmethod
+    def exists(self) -> bool:
+        """Check whether the resource currently exists.
+
+        :return: ``True`` if the resource exists, ``False`` otherwise.
+        """
+
+    @abstractmethod
+    def delete(self) -> None:
+        """Delete the resource."""

--- a/tests/aws/asg/test_exists_delete.py
+++ b/tests/aws/asg/test_exists_delete.py
@@ -1,0 +1,78 @@
+"""Tests for ASG.exists and ASG.delete()."""
+
+from unittest import mock
+
+from botocore.exceptions import ClientError
+
+from infrahouse_core.aws.asg import ASG
+
+
+def _make_client_error(code):
+    """Helper to create a ClientError with a specific error code."""
+    return ClientError({"Error": {"Code": code, "Message": "test"}}, "test_operation")
+
+
+def test_exists_true():
+    """exists returns True when the ASG is found."""
+    asg = ASG("my-asg", region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.describe_auto_scaling_groups.return_value = {"AutoScalingGroups": [{"AutoScalingGroupName": "my-asg"}]}
+    with mock.patch.object(ASG, "_autoscaling_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        assert asg.exists is True
+        mock_client.describe_auto_scaling_groups.assert_called_once_with(AutoScalingGroupNames=["my-asg"])
+
+
+def test_exists_false():
+    """exists returns False when the ASG is not found."""
+    asg = ASG("my-asg", region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.describe_auto_scaling_groups.return_value = {"AutoScalingGroups": []}
+    with mock.patch.object(ASG, "_autoscaling_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        assert asg.exists is False
+
+
+def test_delete():
+    """delete() calls delete_auto_scaling_group with ForceDelete."""
+    asg = ASG("my-asg", region="us-east-1")
+    mock_client = mock.MagicMock()
+    with mock.patch.object(ASG, "_autoscaling_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        asg.delete()
+        mock_client.delete_auto_scaling_group.assert_called_once_with(
+            AutoScalingGroupName="my-asg",
+            ForceDelete=True,
+        )
+
+
+def test_delete_not_exists():
+    """delete() on a non-existent ASG is a no-op."""
+    asg = ASG("my-asg", region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.delete_auto_scaling_group.side_effect = _make_client_error("ValidationError")
+    with mock.patch.object(ASG, "_autoscaling_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        asg.delete()  # Should not raise
+        mock_client.delete_auto_scaling_group.assert_called_once()
+
+
+def test_delete_no_force():
+    """delete(force_delete=False) passes ForceDelete=False."""
+    asg = ASG("my-asg", region="us-east-1")
+    mock_client = mock.MagicMock()
+    with mock.patch.object(ASG, "_autoscaling_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        asg.delete(force_delete=False)
+        mock_client.delete_auto_scaling_group.assert_called_once_with(
+            AutoScalingGroupName="my-asg",
+            ForceDelete=False,
+        )
+
+
+def test_delete_unexpected_error():
+    """delete() re-raises unexpected errors."""
+    asg = ASG("my-asg", region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.delete_auto_scaling_group.side_effect = _make_client_error("AccessDeniedException")
+    with mock.patch.object(ASG, "_autoscaling_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        try:
+            asg.delete()
+            assert False, "Should have raised ClientError"
+        except ClientError as err:
+            assert err.response["Error"]["Code"] == "AccessDeniedException"

--- a/tests/aws/dynamodb/test_exists_delete.py
+++ b/tests/aws/dynamodb/test_exists_delete.py
@@ -1,0 +1,82 @@
+"""Tests for DynamoDBTable.exists and DynamoDBTable.delete()."""
+
+from unittest import mock
+
+from botocore.exceptions import ClientError
+
+from infrahouse_core.aws.dynamodb import DynamoDBTable
+
+
+def _make_client_error(code):
+    """Helper to create a ClientError with a specific error code."""
+    return ClientError({"Error": {"Code": code, "Message": "test"}}, "test_operation")
+
+
+def test_exists_true():
+    """exists returns True when the table is found."""
+    table = DynamoDBTable("my-table", region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.describe_table.return_value = {"Table": {"TableName": "my-table"}}
+
+    with mock.patch.object(DynamoDBTable, "_dynamodb_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        assert table.exists is True
+        mock_client.describe_table.assert_called_once_with(TableName="my-table")
+
+
+def test_exists_false():
+    """exists returns False when the table does not exist."""
+    table = DynamoDBTable("my-table", region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.describe_table.side_effect = _make_client_error("ResourceNotFoundException")
+
+    with mock.patch.object(DynamoDBTable, "_dynamodb_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        assert table.exists is False
+
+
+def test_exists_unexpected_error():
+    """Unexpected errors are re-raised."""
+    table = DynamoDBTable("my-table", region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.describe_table.side_effect = _make_client_error("AccessDeniedException")
+
+    with mock.patch.object(DynamoDBTable, "_dynamodb_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        try:
+            _ = table.exists
+            assert False, "Should have raised ClientError"
+        except ClientError as err:
+            assert err.response["Error"]["Code"] == "AccessDeniedException"
+
+
+def test_delete():
+    """delete() calls delete_table."""
+    table = DynamoDBTable("my-table", region="us-east-1")
+    mock_client = mock.MagicMock()
+
+    with mock.patch.object(DynamoDBTable, "_dynamodb_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        table.delete()
+        mock_client.delete_table.assert_called_once_with(TableName="my-table")
+
+
+def test_delete_not_exists():
+    """delete() on a non-existent table is a no-op."""
+    table = DynamoDBTable("my-table", region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.delete_table.side_effect = _make_client_error("ResourceNotFoundException")
+
+    with mock.patch.object(DynamoDBTable, "_dynamodb_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        table.delete()  # Should not raise
+        mock_client.delete_table.assert_called_once()
+
+
+def test_delete_unexpected_error():
+    """delete() re-raises unexpected errors."""
+    table = DynamoDBTable("my-table", region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.delete_table.side_effect = _make_client_error("AccessDeniedException")
+
+    with mock.patch.object(DynamoDBTable, "_dynamodb_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        try:
+            table.delete()
+            assert False, "Should have raised ClientError"
+        except ClientError as err:
+            assert err.response["Error"]["Code"] == "AccessDeniedException"

--- a/tests/aws/ec2_instance/test_exists_delete.py
+++ b/tests/aws/ec2_instance/test_exists_delete.py
@@ -1,0 +1,111 @@
+"""Tests for EC2Instance.exists and EC2Instance.delete()."""
+
+from unittest import mock
+
+from botocore.exceptions import ClientError
+
+from infrahouse_core.aws.ec2_instance import EC2Instance
+
+
+def _make_client_error(code):
+    """Helper to create a ClientError with a specific error code."""
+    return ClientError({"Error": {"Code": code, "Message": "test"}}, "test_operation")
+
+
+def _make_instance(instance_id="i-1234567890abcdef0", state="running"):
+    """Create an EC2Instance with a mocked ec2 client returning the given state."""
+    mock_client = mock.MagicMock()
+    mock_client.describe_instances.return_value = {
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "State": {"Name": state},
+                        "Tags": [{"Key": "Name", "Value": "test"}],
+                        "PrivateDnsName": "ip-10-0-0-1.ec2.internal",
+                        "PrivateIpAddress": "10.0.0.1",
+                    }
+                ]
+            }
+        ]
+    }
+    instance = EC2Instance(instance_id=instance_id, ec2_client=mock_client)
+    return instance, mock_client
+
+
+def test_exists_running():
+    """A running instance exists."""
+    instance, _ = _make_instance(state="running")
+    assert instance.exists is True
+
+
+def test_exists_stopped():
+    """A stopped instance exists."""
+    instance, _ = _make_instance(state="stopped")
+    assert instance.exists is True
+
+
+def test_exists_terminated():
+    """A terminated instance does not exist."""
+    instance, _ = _make_instance(state="terminated")
+    assert instance.exists is False
+
+
+def test_exists_shutting_down():
+    """A shutting-down instance does not exist."""
+    instance, _ = _make_instance(state="shutting-down")
+    assert instance.exists is False
+
+
+def test_exists_not_found():
+    """An instance that doesn't exist in AWS returns False."""
+    instance_id = "i-0abcdef1234567890"
+    mock_client = mock.MagicMock()
+    mock_client.describe_instances.side_effect = _make_client_error("InvalidInstanceID.NotFound")
+
+    instance = EC2Instance(instance_id=instance_id, ec2_client=mock_client)
+    assert instance.exists is False
+
+
+def test_exists_unexpected_error():
+    """Unexpected errors are re-raised."""
+    instance_id = "i-1234567890abcdef0"
+    mock_client = mock.MagicMock()
+    mock_client.describe_instances.side_effect = _make_client_error("UnauthorizedAccess")
+
+    instance = EC2Instance(instance_id=instance_id, ec2_client=mock_client)
+    try:
+        _ = instance.exists
+        assert False, "Should have raised ClientError"
+    except ClientError as err:
+        assert err.response["Error"]["Code"] == "UnauthorizedAccess"
+
+
+def test_delete_running():
+    """delete() terminates a running instance."""
+    instance, mock_client = _make_instance(state="running")
+    instance.delete()
+    mock_client.terminate_instances.assert_called_once_with(InstanceIds=["i-1234567890abcdef0"])
+
+
+def test_delete_already_terminated():
+    """delete() on a terminated instance is a no-op (OperationNotPermitted)."""
+    instance, mock_client = _make_instance(state="terminated")
+    error = ClientError(
+        {"Error": {"Code": "OperationNotPermitted", "Message": "instance is terminated"}},
+        "TerminateInstances",
+    )
+    mock_client.terminate_instances.side_effect = error
+    instance.delete()  # Should not raise
+    mock_client.terminate_instances.assert_called_once()
+
+
+def test_delete_not_found():
+    """delete() on a non-existent instance is a no-op."""
+    instance_id = "i-0abcdef1234567890"
+    mock_client = mock.MagicMock()
+    mock_client.terminate_instances.side_effect = _make_client_error("InvalidInstanceID.NotFound")
+
+    instance = EC2Instance(instance_id=instance_id, ec2_client=mock_client)
+    instance.delete()  # Should not raise
+    mock_client.terminate_instances.assert_called_once()

--- a/tests/aws/route53/test_exists_delete.py
+++ b/tests/aws/route53/test_exists_delete.py
@@ -1,0 +1,124 @@
+"""Tests for Zone.exists and Zone.delete()."""
+
+from unittest import mock
+
+from infrahouse_core.aws.route53.exceptions import IHZoneNotFound
+from infrahouse_core.aws.route53.zone import Zone
+
+
+def test_exists_true():
+    """exists returns True when the zone is found."""
+    zone_id = "Z1234567890ABC"
+    mock_client = mock.MagicMock()
+    mock_client.get_hosted_zone.return_value = {"HostedZone": {"Id": f"/hostedzone/{zone_id}", "Name": "example.com."}}
+    with mock.patch.object(Zone, "_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        zone = Zone(zone_id=zone_id)
+        assert zone.exists is True
+        mock_client.get_hosted_zone.assert_called_once_with(Id=zone_id)
+
+
+def test_exists_false_no_such_zone():
+    """exists returns False when NoSuchHostedZone is raised."""
+    zone_id = "Z1234567890ABC"
+    mock_client = mock.MagicMock()
+    mock_client.exceptions.NoSuchHostedZone = type("NoSuchHostedZone", (Exception,), {})
+    mock_client.get_hosted_zone.side_effect = mock_client.exceptions.NoSuchHostedZone("not found")
+
+    with mock.patch.object(Zone, "_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        zone = Zone(zone_id=zone_id)
+        assert zone.exists is False
+
+
+def test_exists_false_zone_not_found_by_name():
+    """exists returns False when zone lookup by name raises IHZoneNotFound."""
+    mock_client = mock.MagicMock()
+    mock_client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/ZOTHER", "Name": "other.com."}],
+    }
+    with mock.patch.object(Zone, "_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        zone = Zone(zone_name="nonexistent.com")
+        assert zone.exists is False
+
+
+def test_delete():
+    """delete() removes all non-NS/SOA records and deletes the zone."""
+    zone_id = "Z1234567890ABC"
+    mock_client = mock.MagicMock()
+    mock_client.get_hosted_zone.return_value = {"HostedZone": {"Id": f"/hostedzone/{zone_id}", "Name": "example.com."}}
+
+    paginator = mock.MagicMock()
+    paginator.paginate.return_value = [
+        {
+            "ResourceRecordSets": [
+                {"Name": "example.com.", "Type": "NS", "TTL": 300, "ResourceRecords": [{"Value": "ns1.example.com."}]},
+                {"Name": "example.com.", "Type": "SOA", "TTL": 300, "ResourceRecords": [{"Value": "soa data"}]},
+                {
+                    "Name": "foo.example.com.",
+                    "Type": "A",
+                    "TTL": 300,
+                    "ResourceRecords": [{"Value": "10.0.0.1"}],
+                },
+                {
+                    "Name": "bar.example.com.",
+                    "Type": "CNAME",
+                    "TTL": 300,
+                    "ResourceRecords": [{"Value": "baz.example.com."}],
+                },
+            ]
+        }
+    ]
+    mock_client.get_paginator.return_value = paginator
+
+    with mock.patch.object(Zone, "_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        zone = Zone(zone_id=zone_id)
+        zone.delete()
+
+        # Should have deleted A and CNAME records, but not NS and SOA
+        mock_client.change_resource_record_sets.assert_called_once()
+        call_args = mock_client.change_resource_record_sets.call_args
+        changes = call_args[1]["ChangeBatch"]["Changes"]
+        assert len(changes) == 2
+        assert all(c["Action"] == "DELETE" for c in changes)
+        deleted_types = {c["ResourceRecordSet"]["Type"] for c in changes}
+        assert deleted_types == {"A", "CNAME"}
+
+        mock_client.delete_hosted_zone.assert_called_once_with(Id=zone_id)
+
+
+def test_delete_not_exists():
+    """delete() on a non-existent zone is a no-op."""
+    mock_client = mock.MagicMock()
+    mock_client.list_hosted_zones_by_name.return_value = {
+        "HostedZones": [{"Id": "/hostedzone/ZOTHER", "Name": "other.com."}],
+    }
+    with mock.patch.object(Zone, "_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        zone = Zone(zone_name="nonexistent.com")
+        zone.delete()  # Should not raise
+        mock_client.delete_hosted_zone.assert_not_called()
+
+
+def test_delete_empty_zone():
+    """delete() on a zone with only NS/SOA records still deletes the zone."""
+    zone_id = "Z1234567890ABC"
+    mock_client = mock.MagicMock()
+    mock_client.get_hosted_zone.return_value = {"HostedZone": {"Id": f"/hostedzone/{zone_id}", "Name": "example.com."}}
+
+    paginator = mock.MagicMock()
+    paginator.paginate.return_value = [
+        {
+            "ResourceRecordSets": [
+                {"Name": "example.com.", "Type": "NS", "TTL": 300, "ResourceRecords": [{"Value": "ns1.example.com."}]},
+                {"Name": "example.com.", "Type": "SOA", "TTL": 300, "ResourceRecords": [{"Value": "soa data"}]},
+            ]
+        }
+    ]
+    mock_client.get_paginator.return_value = paginator
+
+    with mock.patch.object(Zone, "_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        zone = Zone(zone_id=zone_id)
+        zone.delete()
+
+        # No change_resource_record_sets call (nothing to delete)
+        mock_client.change_resource_record_sets.assert_not_called()
+        # But zone itself is deleted
+        mock_client.delete_hosted_zone.assert_called_once_with(Id=zone_id)

--- a/tests/aws/test_base.py
+++ b/tests/aws/test_base.py
@@ -1,0 +1,37 @@
+"""Tests for AWSResource base class."""
+
+import pytest
+
+from infrahouse_core.aws.base import AWSResource
+
+
+def test_cannot_instantiate():
+    """AWSResource cannot be instantiated directly (abstract class)."""
+    with pytest.raises(TypeError):
+        AWSResource("some-id", "ec2", region="us-east-1")
+
+
+def test_subclass_must_implement_both():
+    """A subclass that only implements delete() still cannot be instantiated."""
+
+    class PartialResource(AWSResource):
+        def delete(self) -> None:
+            pass
+
+    with pytest.raises(TypeError):
+        PartialResource("some-id", "ec2")
+
+
+def test_complete_subclass():
+    """A subclass implementing both exists and delete() can be instantiated."""
+
+    class ConcreteResource(AWSResource):
+        @property
+        def exists(self) -> bool:
+            return True
+
+        def delete(self) -> None:
+            pass
+
+    resource = ConcreteResource("some-id", "ec2", region="us-east-1")
+    assert resource.exists is True


### PR DESCRIPTION
  ## Summary

  Closes #83.

  - Add `AWSResource` abstract base class (`abc.ABC`) defining the `exists` / `delete()` contract
  - Add idempotent `exists` property and `delete()` method to `ASG`, `EC2Instance`, `DynamoDBTable`, and `Route53 Zone`
  - `delete()` methods use try/except (EAFP) instead of check-then-act to avoid TOCTOU race conditions
  - Skip DynamoDB integration tests when IAM credentials lack required permissions
  - Add `base` module to Sphinx docs and document the interface pattern in `CLAUDE.md`

  ## Details

  All `delete()` methods are idempotent — deleting a non-existent resource is a no-op. Error codes handled per service:

  | Class | "Not found" error caught |
  |-------|--------------------------|
  | ASG | `ValidationError` |
  | EC2Instance | `InvalidInstanceID.NotFound`, `OperationNotPermitted` (already terminated) |
  | DynamoDBTable | `ResourceNotFoundException` |
  | Zone | `IHZoneNotFound` (name lookup), `NoSuchHostedZone` (API) |

  Existing classes do not inherit from `AWSResource` to avoid breaking their constructor signatures. The base class is ready for new resource classes in #84–#90.

  ## Test plan

  - [x] 29 new unit tests covering exists/delete for all four classes plus the base class
  - [x] Base class tests verify ABC enforcement (TypeError on direct instantiation, partial subclass)
  - [x] All 84 tests pass (excluding pre-existing Windows path failures)
  - [x] pylint 10/10, black clean, isort clean

