### PR TITLE
feat: accept optional boto3.Session in resource classes

### DIFF
--- a/src/infrahouse_core/aws/acm_certificate.py
+++ b/src/infrahouse_core/aws/acm_certificate.py
@@ -24,8 +24,8 @@ class ACMCertificate(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, certificate_arn, region=None, role_arn=None):
-        super().__init__(certificate_arn, "acm", region=region, role_arn=role_arn)
+    def __init__(self, certificate_arn, region=None, role_arn=None, session=None):
+        super().__init__(certificate_arn, "acm", region=region, role_arn=role_arn, session=session)
 
     @property
     def certificate_arn(self) -> str:

--- a/src/infrahouse_core/aws/asg_instance.py
+++ b/src/infrahouse_core/aws/asg_instance.py
@@ -70,8 +70,12 @@ class ASGInstance(EC2Instance):
     @property
     def _autoscaling_client(self):
         if self._autoscaling_client_instance is None:
-            # Use role_arn from parent EC2Instance class
-            self._autoscaling_client_instance = get_client("autoscaling", region=self._region, role_arn=self._role_arn)
+            if self._session is not None:
+                self._autoscaling_client_instance = self._session.client("autoscaling", region_name=self._region)
+            else:
+                self._autoscaling_client_instance = get_client(
+                    "autoscaling", region=self._region, role_arn=self._role_arn
+                )
             LOG.debug("Created autoscaling client in %s region", self._autoscaling_client_instance.meta.region_name)
         return self._autoscaling_client_instance
 

--- a/src/infrahouse_core/aws/base.py
+++ b/src/infrahouse_core/aws/base.py
@@ -25,24 +25,32 @@ class AWSResource(ABC):
         (e.g. ``"ec2"``, ``"dynamodb"``).
     :param region: AWS region.
     :param role_arn: IAM role ARN for cross-account access.
+    :param session: Pre-configured ``boto3.Session``.  When provided the
+        client is created from this session instead of via :func:`get_client`.
     """
 
-    def __init__(self, resource_id, service_name, region=None, role_arn=None):
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self, resource_id, service_name, region=None, role_arn=None, session=None
+    ):
         self._resource_id = resource_id
         self._service_name = service_name
         self._region = region
         self._role_arn = role_arn
+        self._session = session
         self._client_instance = None
 
     @property
     def _client(self):
         """Lazy-loaded boto3 client via :func:`get_client`."""
         if self._client_instance is None:
-            self._client_instance = get_client(
-                self._service_name,
-                region=self._region,
-                role_arn=self._role_arn,
-            )
+            if self._session is not None:
+                self._client_instance = self._session.client(self._service_name, region_name=self._region)
+            else:
+                self._client_instance = get_client(
+                    self._service_name,
+                    region=self._region,
+                    role_arn=self._role_arn,
+                )
             LOG.debug(
                 "Created %s client in %s region",
                 self._service_name,

--- a/src/infrahouse_core/aws/cloudfront_cache_policy.py
+++ b/src/infrahouse_core/aws/cloudfront_cache_policy.py
@@ -23,8 +23,8 @@ class CloudFrontCachePolicy(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, policy_id, region=None, role_arn=None):
-        super().__init__(policy_id, "cloudfront", region=region, role_arn=role_arn)
+    def __init__(self, policy_id, region=None, role_arn=None, session=None):
+        super().__init__(policy_id, "cloudfront", region=region, role_arn=role_arn, session=session)
 
     @property
     def policy_id(self) -> str:

--- a/src/infrahouse_core/aws/cloudfront_distribution.py
+++ b/src/infrahouse_core/aws/cloudfront_distribution.py
@@ -36,8 +36,8 @@ class CloudFrontDistribution(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, distribution_id, region=None, role_arn=None):
-        super().__init__(distribution_id, "cloudfront", region=region, role_arn=role_arn)
+    def __init__(self, distribution_id, region=None, role_arn=None, session=None):
+        super().__init__(distribution_id, "cloudfront", region=region, role_arn=role_arn, session=session)
 
     @property
     def distribution_id(self) -> str:

--- a/src/infrahouse_core/aws/cloudfront_function.py
+++ b/src/infrahouse_core/aws/cloudfront_function.py
@@ -23,8 +23,8 @@ class CloudFrontFunction(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, function_name, region=None, role_arn=None):
-        super().__init__(function_name, "cloudfront", region=region, role_arn=role_arn)
+    def __init__(self, function_name, region=None, role_arn=None, session=None):
+        super().__init__(function_name, "cloudfront", region=region, role_arn=role_arn, session=session)
 
     @property
     def function_name(self) -> str:

--- a/src/infrahouse_core/aws/cloudfront_response_headers_policy.py
+++ b/src/infrahouse_core/aws/cloudfront_response_headers_policy.py
@@ -24,8 +24,8 @@ class CloudFrontResponseHeadersPolicy(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, policy_id, region=None, role_arn=None):
-        super().__init__(policy_id, "cloudfront", region=region, role_arn=role_arn)
+    def __init__(self, policy_id, region=None, role_arn=None, session=None):
+        super().__init__(policy_id, "cloudfront", region=region, role_arn=role_arn, session=session)
 
     @property
     def policy_id(self) -> str:

--- a/src/infrahouse_core/aws/cloudwatch_log_group.py
+++ b/src/infrahouse_core/aws/cloudwatch_log_group.py
@@ -23,8 +23,8 @@ class CloudWatchLogGroup(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, log_group_name, region=None, role_arn=None):
-        super().__init__(log_group_name, "logs", region=region, role_arn=role_arn)
+    def __init__(self, log_group_name, region=None, role_arn=None, session=None):
+        super().__init__(log_group_name, "logs", region=region, role_arn=role_arn, session=session)
 
     @property
     def log_group_name(self) -> str:

--- a/src/infrahouse_core/aws/ec2_instance.py
+++ b/src/infrahouse_core/aws/ec2_instance.py
@@ -66,6 +66,7 @@ class EC2Instance:
         ec2_client: Session = None,
         ssm_client: Session = None,
         role_arn: str = None,
+        session: Session = None,
     ):
         """
         :param instance_id: Instance id. If omitted, the local instance is read from metadata.
@@ -78,6 +79,9 @@ class EC2Instance:
         :type ssm_client: Session
         :param role_arn: Use this IAM role to create boto3 clients.
         :type role_arn: str
+        :param session: Pre-configured ``boto3.Session``.  When provided, clients are
+            created from this session instead of via :func:`get_client`.
+        :type session: boto3.Session
         """
         if ec2_client is not None:
             warnings.warn(
@@ -102,6 +106,7 @@ class EC2Instance:
         self._ec2_client = ec2_client
         self._ssm_client = ssm_client
         self._role_arn = role_arn
+        self._session = session
 
     @property
     def availability_zone(self) -> str:
@@ -119,7 +124,10 @@ class EC2Instance:
         :return: Boto3 EC2 client.
         """
         if self._ec2_client is None:
-            self._ec2_client = get_client("ec2", region=self._region, role_arn=self._role_arn)
+            if self._session is not None:
+                self._ec2_client = self._session.client("ec2", region_name=self._region)
+            else:
+                self._ec2_client = get_client("ec2", region=self._region, role_arn=self._role_arn)
         return self._ec2_client
 
     @property
@@ -176,7 +184,10 @@ class EC2Instance:
         :return: Boto3 SSM client.
         """
         if self._ssm_client is None:
-            self._ssm_client = get_client("ssm", region=self._region, role_arn=self._role_arn)
+            if self._session is not None:
+                self._ssm_client = self._session.client("ssm", region_name=self._region)
+            else:
+                self._ssm_client = get_client("ssm", region=self._region, role_arn=self._role_arn)
         return self._ssm_client
 
     @property

--- a/src/infrahouse_core/aws/elb_load_balancer.py
+++ b/src/infrahouse_core/aws/elb_load_balancer.py
@@ -24,8 +24,8 @@ class ELBLoadBalancer(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, load_balancer_arn, region=None, role_arn=None):
-        super().__init__(load_balancer_arn, "elbv2", region=region, role_arn=role_arn)
+    def __init__(self, load_balancer_arn, region=None, role_arn=None, session=None):
+        super().__init__(load_balancer_arn, "elbv2", region=region, role_arn=role_arn, session=session)
 
     @property
     def load_balancer_arn(self) -> str:

--- a/src/infrahouse_core/aws/elb_target_group.py
+++ b/src/infrahouse_core/aws/elb_target_group.py
@@ -23,8 +23,8 @@ class ELBTargetGroup(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, target_group_arn, region=None, role_arn=None):
-        super().__init__(target_group_arn, "elbv2", region=region, role_arn=role_arn)
+    def __init__(self, target_group_arn, region=None, role_arn=None, session=None):
+        super().__init__(target_group_arn, "elbv2", region=region, role_arn=role_arn, session=session)
 
     @property
     def target_group_arn(self) -> str:

--- a/src/infrahouse_core/aws/eventbridge_rule.py
+++ b/src/infrahouse_core/aws/eventbridge_rule.py
@@ -25,8 +25,10 @@ class EventBridgeRule(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, rule_name, event_bus_name="default", region=None, role_arn=None):
-        super().__init__(rule_name, "events", region=region, role_arn=role_arn)
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self, rule_name, event_bus_name="default", region=None, role_arn=None, session=None
+    ):
+        super().__init__(rule_name, "events", region=region, role_arn=role_arn, session=session)
         self._event_bus_name = event_bus_name
 
     @property

--- a/src/infrahouse_core/aws/iam_group.py
+++ b/src/infrahouse_core/aws/iam_group.py
@@ -30,8 +30,8 @@ class IAMGroup(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, group_name, region=None, role_arn=None):
-        super().__init__(group_name, "iam", region=region, role_arn=role_arn)
+    def __init__(self, group_name, region=None, role_arn=None, session=None):
+        super().__init__(group_name, "iam", region=region, role_arn=role_arn, session=session)
 
     @property
     def group_name(self) -> str:

--- a/src/infrahouse_core/aws/iam_instance_profile.py
+++ b/src/infrahouse_core/aws/iam_instance_profile.py
@@ -27,8 +27,8 @@ class IAMInstanceProfile(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, profile_name, region=None, role_arn=None):
-        super().__init__(profile_name, "iam", region=region, role_arn=role_arn)
+    def __init__(self, profile_name, region=None, role_arn=None, session=None):
+        super().__init__(profile_name, "iam", region=region, role_arn=role_arn, session=session)
 
     @property
     def profile_name(self) -> str:

--- a/src/infrahouse_core/aws/iam_policy.py
+++ b/src/infrahouse_core/aws/iam_policy.py
@@ -30,8 +30,8 @@ class IAMPolicy(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, policy_arn, region=None, role_arn=None):
-        super().__init__(policy_arn, "iam", region=region, role_arn=role_arn)
+    def __init__(self, policy_arn, region=None, role_arn=None, session=None):
+        super().__init__(policy_arn, "iam", region=region, role_arn=role_arn, session=session)
         self._attached_roles = None
         self._attached_users = None
         self._attached_groups = None

--- a/src/infrahouse_core/aws/iam_role.py
+++ b/src/infrahouse_core/aws/iam_role.py
@@ -30,8 +30,8 @@ class IAMRole(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, role_name, region=None, role_arn=None):
-        super().__init__(role_name, "iam", region=region, role_arn=role_arn)
+    def __init__(self, role_name, region=None, role_arn=None, session=None):
+        super().__init__(role_name, "iam", region=region, role_arn=role_arn, session=session)
 
     @property
     def role_name(self) -> str:

--- a/src/infrahouse_core/aws/iam_user.py
+++ b/src/infrahouse_core/aws/iam_user.py
@@ -31,8 +31,8 @@ class IAMUser(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, user_name, region=None, role_arn=None):
-        super().__init__(user_name, "iam", region=region, role_arn=role_arn)
+    def __init__(self, user_name, region=None, role_arn=None, session=None):
+        super().__init__(user_name, "iam", region=region, role_arn=role_arn, session=session)
 
     @property
     def user_name(self) -> str:

--- a/src/infrahouse_core/aws/lambda_function.py
+++ b/src/infrahouse_core/aws/lambda_function.py
@@ -23,8 +23,8 @@ class LambdaFunction(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, function_name, region=None, role_arn=None):
-        super().__init__(function_name, "lambda", region=region, role_arn=role_arn)
+    def __init__(self, function_name, region=None, role_arn=None, session=None):
+        super().__init__(function_name, "lambda", region=region, role_arn=role_arn, session=session)
 
     @property
     def function_name(self) -> str:

--- a/src/infrahouse_core/aws/nat_gateway.py
+++ b/src/infrahouse_core/aws/nat_gateway.py
@@ -28,8 +28,8 @@ class NATGateway(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, nat_gateway_id, region=None, role_arn=None):
-        super().__init__(nat_gateway_id, "ec2", region=region, role_arn=role_arn)
+    def __init__(self, nat_gateway_id, region=None, role_arn=None, session=None):
+        super().__init__(nat_gateway_id, "ec2", region=region, role_arn=role_arn, session=session)
 
     @property
     def nat_gateway_id(self) -> str:

--- a/src/infrahouse_core/aws/route53/zone.py
+++ b/src/infrahouse_core/aws/route53/zone.py
@@ -29,7 +29,9 @@ class Zone:
     :type zone_name: str
     """
 
-    def __init__(self, zone_id: str = None, zone_name: str = None, region: str = None, role_arn: str = None):
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self, zone_id: str = None, zone_name: str = None, region: str = None, role_arn: str = None, session=None
+    ):
         if zone_name is None and zone_id is None:
             raise RuntimeError("Either zone_id or zone_name must be passed. Both can't be None.")
 
@@ -43,6 +45,7 @@ class Zone:
         self._zone_name = zone_name
         self._region = region
         self._role_arn = role_arn
+        self._session = session
         self._client_instance = None
 
     @property
@@ -250,7 +253,10 @@ class Zone:
     @property
     def _client(self):
         if self._client_instance is None:
-            self._client_instance = get_client("route53", region=self._region, role_arn=self._role_arn)
+            if self._session is not None:
+                self._client_instance = self._session.client("route53", region_name=self._region)
+            else:
+                self._client_instance = get_client("route53", region=self._region, role_arn=self._role_arn)
             LOG.debug("Created route53 client in %s region", self._client_instance.meta.region_name)
         return self._client_instance
 

--- a/src/infrahouse_core/aws/s3_bucket.py
+++ b/src/infrahouse_core/aws/s3_bucket.py
@@ -27,8 +27,8 @@ class S3Bucket(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, bucket_name, region=None, role_arn=None):
-        super().__init__(bucket_name, "s3", region=region, role_arn=role_arn)
+    def __init__(self, bucket_name, region=None, role_arn=None, session=None):
+        super().__init__(bucket_name, "s3", region=region, role_arn=role_arn, session=session)
 
     @property
     def bucket_name(self) -> str:

--- a/src/infrahouse_core/aws/secretsmanager.py
+++ b/src/infrahouse_core/aws/secretsmanager.py
@@ -26,16 +26,20 @@ class Secret:
     :type role_arn: str
     """
 
-    def __init__(self, secret_name: str, region: str = None, role_arn: str = None):
+    def __init__(self, secret_name: str, region: str = None, role_arn: str = None, session=None):
         self._secret_name = secret_name
         self._region = region
         self._role_arn = role_arn
+        self._session = session
         self.__client = None
 
     def _client(self):
         """Lazily create and return the Secrets Manager client."""
         if self.__client is None:
-            self.__client = get_client("secretsmanager", role_arn=self._role_arn, region=self._region)
+            if self._session is not None:
+                self.__client = self._session.client("secretsmanager", region_name=self._region)
+            else:
+                self.__client = get_client("secretsmanager", role_arn=self._role_arn, region=self._region)
         return self.__client
 
     @property

--- a/src/infrahouse_core/aws/security_group.py
+++ b/src/infrahouse_core/aws/security_group.py
@@ -26,8 +26,8 @@ class SecurityGroup(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, group_id, region=None, role_arn=None):
-        super().__init__(group_id, "ec2", region=region, role_arn=role_arn)
+    def __init__(self, group_id, region=None, role_arn=None, session=None):
+        super().__init__(group_id, "ec2", region=region, role_arn=role_arn, session=session)
 
     @property
     def group_id(self) -> str:

--- a/src/infrahouse_core/aws/sns_topic.py
+++ b/src/infrahouse_core/aws/sns_topic.py
@@ -23,8 +23,8 @@ class SNSTopic(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, topic_arn, region=None, role_arn=None):
-        super().__init__(topic_arn, "sns", region=region, role_arn=role_arn)
+    def __init__(self, topic_arn, region=None, role_arn=None, session=None):
+        super().__init__(topic_arn, "sns", region=region, role_arn=role_arn, session=session)
 
     @property
     def topic_arn(self) -> str:

--- a/src/infrahouse_core/aws/sqs_queue.py
+++ b/src/infrahouse_core/aws/sqs_queue.py
@@ -26,8 +26,8 @@ class SQSQueue(AWSResource):
     :param role_arn: IAM role ARN for cross-account access.
     """
 
-    def __init__(self, queue_url, region=None, role_arn=None):
-        super().__init__(queue_url, "sqs", region=region, role_arn=role_arn)
+    def __init__(self, queue_url, region=None, role_arn=None, session=None):
+        super().__init__(queue_url, "sqs", region=region, role_arn=role_arn, session=session)
 
     @property
     def queue_url(self) -> str:

--- a/tests/aws/asg/test_role.py
+++ b/tests/aws/asg/test_role.py
@@ -81,4 +81,6 @@ def test_instances():
     ):
         asg = ASG("foo-asg", role_arn="foo")
         assert len(asg.instances) > 0
-        mock_asg_instance.assert_called_once_with(instance_id="i-0d02e8a467749ad97", region=None, role_arn="foo")
+        mock_asg_instance.assert_called_once_with(
+            instance_id="i-0d02e8a467749ad97", region=None, role_arn="foo", session=None
+        )

--- a/tests/aws/test_session.py
+++ b/tests/aws/test_session.py
@@ -1,0 +1,344 @@
+"""Tests for the ``session`` parameter across resource classes.
+
+When a pre-configured ``boto3.Session`` is supplied, every resource class
+should create its boto3 client(s) from that session rather than via
+:func:`get_client`.  When ``session`` is *not* supplied the behaviour
+should remain unchanged (backward-compatible).
+"""
+
+# pylint: disable=protected-access
+
+from unittest import mock
+
+from infrahouse_core.aws.asg import ASG
+from infrahouse_core.aws.asg_instance import ASGInstance
+from infrahouse_core.aws.base import AWSResource
+from infrahouse_core.aws.dynamodb import DynamoDBTable
+from infrahouse_core.aws.ec2_instance import EC2Instance
+from infrahouse_core.aws.route53.zone import Zone
+from infrahouse_core.aws.s3_bucket import S3Bucket
+from infrahouse_core.aws.secretsmanager import Secret
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _ConcreteResource(AWSResource):
+    """Minimal concrete subclass used for testing the base class."""
+
+    @property
+    def exists(self) -> bool:
+        return True
+
+    def delete(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# AWSResource base class
+# ---------------------------------------------------------------------------
+
+
+class TestAWSResourceSession:
+    """Session parameter on the AWSResource base class."""
+
+    def test_session_is_stored(self):
+        """The session object is stored on the instance."""
+        mock_session = mock.MagicMock()
+        resource = _ConcreteResource("res-1", "ec2", session=mock_session)
+        assert resource._session is mock_session
+
+    def test_session_none_by_default(self):
+        """session defaults to None when not provided."""
+        resource = _ConcreteResource("res-1", "ec2", region="us-east-1")
+        assert resource._session is None
+
+    @mock.patch("infrahouse_core.aws.base.get_client")
+    def test_client_uses_session_when_provided(self, mock_get_client):
+        """_client creates the client from the session, not get_client."""
+        mock_session = mock.MagicMock()
+        mock_client = mock.MagicMock()
+        mock_session.client.return_value = mock_client
+
+        resource = _ConcreteResource("res-1", "ec2", region="us-west-2", session=mock_session)
+        client = resource._client
+
+        mock_session.client.assert_called_once_with("ec2", region_name="us-west-2")
+        mock_get_client.assert_not_called()
+        assert client is mock_client
+
+    @mock.patch("infrahouse_core.aws.base.get_client")
+    def test_client_uses_get_client_without_session(self, mock_get_client):
+        """_client falls back to get_client when no session is provided."""
+        mock_client = mock.MagicMock()
+        mock_get_client.return_value = mock_client
+
+        resource = _ConcreteResource("res-1", "ec2", region="us-east-1", role_arn="arn:aws:iam::123:role/test")
+        client = resource._client
+
+        mock_get_client.assert_called_once_with("ec2", region="us-east-1", role_arn="arn:aws:iam::123:role/test")
+        assert client is mock_client
+
+    @mock.patch("infrahouse_core.aws.base.get_client")
+    def test_client_is_cached(self, mock_get_client):  # pylint: disable=unused-argument
+        """_client is lazily created and reused on subsequent accesses."""
+        mock_session = mock.MagicMock()
+        mock_session.client.return_value = mock.MagicMock()
+
+        resource = _ConcreteResource("res-1", "ec2", session=mock_session)
+        client1 = resource._client
+        client2 = resource._client
+
+        assert client1 is client2
+        mock_session.client.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# AWSResource subclass (S3Bucket as representative)
+# ---------------------------------------------------------------------------
+
+
+class TestAWSResourceSubclassSession:
+    """Session parameter is forwarded by AWSResource subclasses."""
+
+    @mock.patch("infrahouse_core.aws.base.get_client")
+    def test_s3_bucket_uses_session(self, mock_get_client):
+        """S3Bucket creates its client from the session."""
+        mock_session = mock.MagicMock()
+        mock_client = mock.MagicMock()
+        mock_session.client.return_value = mock_client
+
+        bucket = S3Bucket("my-bucket", region="eu-west-1", session=mock_session)
+        client = bucket._client
+
+        mock_session.client.assert_called_once_with("s3", region_name="eu-west-1")
+        mock_get_client.assert_not_called()
+        assert client is mock_client
+
+    @mock.patch("infrahouse_core.aws.base.get_client")
+    def test_s3_bucket_backward_compatible(self, mock_get_client):
+        """S3Bucket still works without a session (backward compatible)."""
+        mock_client = mock.MagicMock()
+        mock_get_client.return_value = mock_client
+
+        bucket = S3Bucket("my-bucket", region="eu-west-1")
+        client = bucket._client
+
+        mock_get_client.assert_called_once_with("s3", region="eu-west-1", role_arn=None)
+        assert client is mock_client
+
+
+# ---------------------------------------------------------------------------
+# EC2Instance
+# ---------------------------------------------------------------------------
+
+
+class TestEC2InstanceSession:
+    """Session parameter on EC2Instance."""
+
+    @mock.patch("infrahouse_core.aws.ec2_instance.get_client")
+    def test_ec2_client_uses_session(self, mock_get_client):
+        """ec2_client creates the client from the session."""
+        mock_session = mock.MagicMock()
+        mock_client = mock.MagicMock()
+        mock_session.client.return_value = mock_client
+
+        instance = EC2Instance("i-1234567890abcdef0", region="us-east-1", session=mock_session)
+        client = instance.ec2_client
+
+        mock_session.client.assert_called_once_with("ec2", region_name="us-east-1")
+        mock_get_client.assert_not_called()
+        assert client is mock_client
+
+    @mock.patch("infrahouse_core.aws.ec2_instance.get_client")
+    def test_ssm_client_uses_session(self, mock_get_client):
+        """ssm_client creates the client from the session."""
+        mock_session = mock.MagicMock()
+        mock_ec2 = mock.MagicMock()
+        mock_ssm = mock.MagicMock()
+        mock_session.client.side_effect = lambda svc, **kw: mock_ssm if svc == "ssm" else mock_ec2
+
+        instance = EC2Instance("i-1234567890abcdef0", region="us-east-1", session=mock_session)
+        client = instance.ssm_client
+
+        mock_session.client.assert_called_with("ssm", region_name="us-east-1")
+        mock_get_client.assert_not_called()
+        assert client is mock_ssm
+
+    @mock.patch("infrahouse_core.aws.ec2_instance.get_client")
+    def test_ec2_client_backward_compatible(self, mock_get_client):
+        """ec2_client uses get_client when no session is provided."""
+        mock_client = mock.MagicMock()
+        mock_get_client.return_value = mock_client
+
+        instance = EC2Instance("i-1234567890abcdef0", region="us-east-1")
+        client = instance.ec2_client
+
+        mock_get_client.assert_called_once_with("ec2", region="us-east-1", role_arn=None)
+        assert client is mock_client
+
+
+# ---------------------------------------------------------------------------
+# ASG
+# ---------------------------------------------------------------------------
+
+
+class TestASGSession:
+    """Session parameter on ASG."""
+
+    @mock.patch("infrahouse_core.aws.asg.get_client")
+    def test_autoscaling_client_uses_session(self, mock_get_client):
+        """_autoscaling_client creates the client from the session."""
+        mock_session = mock.MagicMock()
+        mock_client = mock.MagicMock()
+        mock_session.client.return_value = mock_client
+
+        asg = ASG("my-asg", region="us-east-1", session=mock_session)
+        client = asg._autoscaling_client
+
+        mock_session.client.assert_called_once_with("autoscaling", region_name="us-east-1")
+        mock_get_client.assert_not_called()
+        assert client is mock_client
+
+    def test_instances_passes_session(self):
+        """ASG.instances passes session through to ASGInstance."""
+        mock_session = mock.MagicMock()
+
+        with (
+            mock.patch.object(
+                ASG,
+                "_describe_auto_scaling_groups",
+                new_callable=mock.PropertyMock,
+                return_value={
+                    "AutoScalingGroups": [
+                        {
+                            "Instances": [
+                                {"InstanceId": "i-abc123"},
+                            ],
+                        }
+                    ],
+                },
+            ),
+            mock.patch.object(ASGInstance, "__init__", return_value=None) as mock_init,
+        ):
+            asg = ASG("my-asg", region="us-west-2", role_arn="arn:aws:iam::123:role/r", session=mock_session)
+            instances = asg.instances
+
+            assert len(instances) == 1
+            mock_init.assert_called_once_with(
+                instance_id="i-abc123",
+                region="us-west-2",
+                role_arn="arn:aws:iam::123:role/r",
+                session=mock_session,
+            )
+
+
+# ---------------------------------------------------------------------------
+# DynamoDBTable
+# ---------------------------------------------------------------------------
+
+
+class TestDynamoDBTableSession:
+    """Session parameter on DynamoDBTable."""
+
+    @mock.patch("infrahouse_core.aws.dynamodb.get_client")
+    def test_dynamodb_client_uses_session(self, mock_get_client):
+        """_dynamodb_client creates the client from the session."""
+        mock_session = mock.MagicMock()
+        mock_client = mock.MagicMock()
+        mock_session.client.return_value = mock_client
+
+        table = DynamoDBTable("my-table", region="us-east-1", session=mock_session)
+        client = table._dynamodb_client
+
+        mock_session.client.assert_called_once_with("dynamodb", region_name="us-east-1")
+        mock_get_client.assert_not_called()
+        assert client is mock_client
+
+    @mock.patch("infrahouse_core.aws.dynamodb.get_resource")
+    def test_table_resource_uses_session(self, mock_get_resource):
+        """_table() creates the resource from the session."""
+        mock_session = mock.MagicMock()
+        mock_resource = mock.MagicMock()
+        mock_table = mock.MagicMock()
+        mock_session.resource.return_value = mock_resource
+        mock_resource.Table.return_value = mock_table
+
+        table = DynamoDBTable("my-table", region="us-east-1", session=mock_session)
+        result = table._table()
+
+        mock_session.resource.assert_called_once_with("dynamodb", region_name="us-east-1")
+        mock_resource.Table.assert_called_once_with("my-table")
+        mock_get_resource.assert_not_called()
+        assert result is mock_table
+
+
+# ---------------------------------------------------------------------------
+# Zone (Route53)
+# ---------------------------------------------------------------------------
+
+
+class TestZoneSession:
+    """Session parameter on Zone."""
+
+    @mock.patch("infrahouse_core.aws.route53.zone.get_client")
+    def test_route53_client_uses_session(self, mock_get_client):
+        """_client creates the client from the session."""
+        mock_session = mock.MagicMock()
+        mock_client = mock.MagicMock()
+        mock_session.client.return_value = mock_client
+
+        zone = Zone(zone_id="Z12345", session=mock_session)
+        client = zone._client
+
+        mock_session.client.assert_called_once_with("route53", region_name=None)
+        mock_get_client.assert_not_called()
+        assert client is mock_client
+
+    @mock.patch("infrahouse_core.aws.route53.zone.get_client")
+    def test_route53_backward_compatible(self, mock_get_client):
+        """_client uses get_client when no session is provided."""
+        mock_client = mock.MagicMock()
+        mock_get_client.return_value = mock_client
+
+        zone = Zone(zone_id="Z12345", region="us-east-1")
+        client = zone._client
+
+        mock_get_client.assert_called_once_with("route53", region="us-east-1", role_arn=None)
+        assert client is mock_client
+
+
+# ---------------------------------------------------------------------------
+# Secret (Secrets Manager)
+# ---------------------------------------------------------------------------
+
+
+class TestSecretSession:
+    """Session parameter on Secret."""
+
+    @mock.patch("infrahouse_core.aws.secretsmanager.get_client")
+    def test_secretsmanager_client_uses_session(self, mock_get_client):
+        """_client() creates the client from the session."""
+        mock_session = mock.MagicMock()
+        mock_client = mock.MagicMock()
+        mock_session.client.return_value = mock_client
+
+        secret = Secret("my-secret", region="us-east-1", session=mock_session)
+        client = secret._client()
+
+        mock_session.client.assert_called_once_with("secretsmanager", region_name="us-east-1")
+        mock_get_client.assert_not_called()
+        assert client is mock_client
+
+    @mock.patch("infrahouse_core.aws.secretsmanager.get_client")
+    def test_secretsmanager_backward_compatible(self, mock_get_client):
+        """_client() uses get_client when no session is provided."""
+        mock_client = mock.MagicMock()
+        mock_get_client.return_value = mock_client
+
+        secret = Secret("my-secret", region="us-east-1")
+        client = secret._client()
+
+        mock_get_client.assert_called_once_with("secretsmanager", role_arn=None, region="us-east-1")
+        assert client is mock_client


### PR DESCRIPTION
  ## Summary

  - Add optional `session` parameter to `AWSResource` base class and all 20 subclasses
  - Add optional `session` parameter to non-AWSResource classes: `EC2Instance`, `ASGInstance`, `ASG`, `DynamoDBTable`, `Zone`, `Secret`
  - When a pre-configured `boto3.Session` is provided, clients are created from it instead of via `get_client()`/`get_resource()`
  - Fix `ASG.instances` to propagate `session` (and `role_arn`) through to `ASGInstance` objects
  - Fully backward-compatible: `session` defaults to `None`

  ## Motivation

  Resource classes previously created their own boto3 clients internally via `get_client()`, ignoring any pre-configured `boto3.Session`. This made it impossible to use SSO profiles, custom credential
  providers, STS session tokens, or mocked sessions for testing.

  Closes #96

  ## Test plan

  - [x] 19 new tests in `tests/aws/test_session.py` covering session usage and backward compatibility for `AWSResource`, `S3Bucket`, `EC2Instance`, `ASG`, `DynamoDBTable`, `Zone`, and `Secret`
  - [x] Updated existing `test_role.py` to verify `session` is passed through `ASG.instances`
  - [x] Full test suite passes (330 passed, 4 skipped)
  - [x] pylint 10.00/10, black/isort clean

