### PR TITLE
Fix Raft IP-vs-hostname comparison and DynamoDB test credentials

### DIFF
--- a/src/infrahouse_core/orchestrator/raft_cluster.py
+++ b/src/infrahouse_core/orchestrator/raft_cluster.py
@@ -79,6 +79,20 @@ class OrchestratorRaftCluster:
             for instance in self._asg.instances
         ]
 
+    def _node_lookup(self, nodes):
+        """Build a dict mapping both private_ip and hostname to each node.
+
+        Raft may identify peers by IP address (e.g. ``"10.1.100.195"``) or by
+        short hostname (e.g. ``"ip-10-1-100-195"``).  This lookup supports both.
+
+        :rtype: dict[str, OrchestratorRaftNode]
+        """
+        lookup = {}
+        for node in nodes:
+            lookup[node.private_ip] = node
+            lookup[node.hostname] = node
+        return lookup
+
     @property
     def leader(self):
         """Return the :class:`OrchestratorRaftNode` that is the current Raft leader.
@@ -89,7 +103,9 @@ class OrchestratorRaftCluster:
         :rtype: OrchestratorRaftNode
         :raises IHRaftLeaderNotFound: If no node reports a leader.
         """
-        for node in self.nodes:
+        nodes = self.nodes
+        lookup = self._node_lookup(nodes)
+        for node in nodes:
             try:
                 leader_addr = node.raft_leader
             except IHRaftPeerError:
@@ -97,10 +113,10 @@ class OrchestratorRaftCluster:
                 continue
             if leader_addr is not None:
                 leader_host = leader_addr.split(":")[0]
-                for candidate in self.nodes:
-                    if candidate.hostname == leader_host:
-                        LOG.info("Found Raft leader at %s", leader_host)
-                        return candidate
+                candidate = lookup.get(leader_host)
+                if candidate is not None:
+                    LOG.info("Found Raft leader at %s", leader_host)
+                    return candidate
                 LOG.warning(
                     "Leader %s is not in the current ASG instance list.",
                     leader_addr,
@@ -117,10 +133,9 @@ class OrchestratorRaftCluster:
 
         :rtype: list[OrchestratorRaftNode]
         """
-        nodes_by_hostname = {node.hostname: node for node in self.nodes}
+        lookup = self._node_lookup(self.nodes)
         return [
-            nodes_by_hostname.get(addr.split(":")[0], OrchestratorRaftNode.from_peer_addr(addr))
-            for addr in self.leader.raft_peers
+            lookup.get(addr.split(":")[0], OrchestratorRaftNode.from_peer_addr(addr)) for addr in self.leader.raft_peers
         ]
 
     def add_peer(self, node):
@@ -157,23 +172,31 @@ class OrchestratorRaftCluster:
         leader = self.leader
         LOG.info("Reconciling Raft peers via leader %s", leader.hostname)
 
-        nodes_by_hostname = {node.hostname: node for node in self.nodes}
-        LOG.debug("Live ASG hostnames: %s", set(nodes_by_hostname))
+        live_nodes = self.nodes
+        LOG.debug("Live ASG instances: %s", [node.hostname for node in live_nodes])
 
-        raft_peers_by_hostname = {
-            addr.split(":")[0]: OrchestratorRaftNode.from_peer_addr(addr) for addr in leader.raft_peers
-        }
-        LOG.debug("Current Raft peer hostnames: %s", set(raft_peers_by_hostname))
+        # Build a map of raft host -> stale node for peers not in the ASG
+        raft_peer_addrs = {}
+        for addr in leader.raft_peers:
+            host = addr.split(":")[0]
+            raft_peer_addrs[host] = OrchestratorRaftNode.from_peer_addr(addr)
+        LOG.debug("Current Raft peer hosts: %s", set(raft_peer_addrs))
 
-        stale_hostnames = set(raft_peers_by_hostname) - set(nodes_by_hostname)
-        missing_hostnames = set(nodes_by_hostname) - set(raft_peers_by_hostname)
+        stale_hosts = (
+            set(raft_peer_addrs) - {node.private_ip for node in live_nodes} - {node.hostname for node in live_nodes}
+        )
+        missing_nodes = [
+            node
+            for node in live_nodes
+            if node.private_ip not in raft_peer_addrs and node.hostname not in raft_peer_addrs
+        ]
 
-        for hostname in stale_hostnames:
-            LOG.info("Removing stale Raft peer %s", hostname)
-            self.remove_peer(raft_peers_by_hostname[hostname])
+        for host in stale_hosts:
+            LOG.info("Removing stale Raft peer %s", host)
+            self.remove_peer(raft_peer_addrs[host])
 
-        for hostname in missing_hostnames:
-            LOG.info("Adding missing Raft peer %s", hostname)
-            self.add_peer(nodes_by_hostname[hostname])
+        for node in missing_nodes:
+            LOG.info("Adding missing Raft peer %s", node.hostname)
+            self.add_peer(node)
 
-        LOG.info("Raft reconcile complete: removed=%d added=%d", len(stale_hostnames), len(missing_hostnames))
+        LOG.info("Raft reconcile complete: removed=%d added=%d", len(stale_hosts), len(missing_nodes))

--- a/tests/aws/dynamodb/conftest.py
+++ b/tests/aws/dynamodb/conftest.py
@@ -30,8 +30,9 @@ def dynamodb_table():
             BillingMode="PAY_PER_REQUEST",
         )
     except ClientError as exc:
-        if exc.response["Error"]["Code"] == "AccessDeniedException":
-            pytest.skip(f"AWS credentials lack dynamodb:CreateTable permission: {exc}")
+        error_code = exc.response["Error"]["Code"]
+        if error_code in ("AccessDeniedException", "UnrecognizedClientException"):
+            pytest.skip(f"AWS credentials not usable ({error_code}): {exc}")
         raise
 
     # Wait for table to be active

--- a/tests/aws/dynamodb/test_lock.py
+++ b/tests/aws/dynamodb/test_lock.py
@@ -7,10 +7,16 @@ from infrahouse_core.aws.dynamodb import DynamoDBTable
 
 
 def _has_aws_credentials():
-    """Check if AWS credentials are available."""
+    """Check if valid AWS credentials are available."""
     try:
-        credentials = boto3.Session().get_credentials()
-        return credentials is not None
+        session = boto3.Session()
+        credentials = session.get_credentials()
+        if credentials is None:
+            return False
+        # Verify the credentials actually work
+        sts = session.client("sts")
+        sts.get_caller_identity()
+        return True
     except Exception:
         return False
 

--- a/tests/orchestrator/test_raft_cluster.py
+++ b/tests/orchestrator/test_raft_cluster.py
@@ -264,6 +264,77 @@ def test_reconcile_raises_on_remove_error():
             cluster.reconcile()
 
 
+def test_leader_found_by_ip():
+    """leader matches when Raft returns IP addresses instead of hostnames (issue #105)."""
+    cluster = OrchestratorRaftCluster("my-asg", region="us-east-1")
+    node1 = mock.MagicMock(spec=OrchestratorRaftNode)
+    node1.hostname = "ip-10-1-1-1"
+    node1.private_ip = "10.1.1.1"
+    node1.raft_leader = "10.1.1.2:10008"
+    node2 = mock.MagicMock(spec=OrchestratorRaftNode)
+    node2.hostname = "ip-10-1-1-2"
+    node2.private_ip = "10.1.1.2"
+    node2.raft_leader = "10.1.1.2:10008"
+    with mock.patch.object(
+        OrchestratorRaftCluster, "nodes", new_callable=mock.PropertyMock, return_value=[node1, node2]
+    ):
+        leader = cluster.leader
+        assert leader.hostname == "ip-10-1-1-2"
+
+
+def test_peers_returns_nodes_by_ip():
+    """peers matches live nodes when Raft uses IP addresses (issue #105)."""
+    cluster = OrchestratorRaftCluster("my-asg", region="us-east-1")
+    mock_leader = mock.MagicMock(spec=OrchestratorRaftNode)
+    mock_leader.raft_peers = ["10.1.1.1:10008", "10.1.1.2:10008"]
+    node1 = mock.MagicMock(spec=OrchestratorRaftNode)
+    node1.hostname = "ip-10-1-1-1"
+    node1.private_ip = "10.1.1.1"
+    node2 = mock.MagicMock(spec=OrchestratorRaftNode)
+    node2.hostname = "ip-10-1-1-2"
+    node2.private_ip = "10.1.1.2"
+    with (
+        mock.patch.object(OrchestratorRaftCluster, "leader", new_callable=mock.PropertyMock, return_value=mock_leader),
+        mock.patch.object(
+            OrchestratorRaftCluster, "nodes", new_callable=mock.PropertyMock, return_value=[node1, node2]
+        ),
+    ):
+        peers = cluster.peers
+        assert len(peers) == 2
+        assert peers[0] is node1
+        assert peers[1] is node2
+
+
+def test_reconcile_with_ip_addresses():
+    """reconcile works when Raft uses IP addresses (issue #105)."""
+    cluster = OrchestratorRaftCluster("my-asg", region="us-east-1")
+    mock_leader = mock.MagicMock(spec=OrchestratorRaftNode)
+    mock_leader.raft_peers = ["10.1.1.1:10008", "10.1.1.2:10008", "10.1.1.99:10008"]
+    node1 = mock.MagicMock(spec=OrchestratorRaftNode)
+    node1.hostname = "ip-10-1-1-1"
+    node1.private_ip = "10.1.1.1"
+    node2 = mock.MagicMock(spec=OrchestratorRaftNode)
+    node2.hostname = "ip-10-1-1-2"
+    node2.private_ip = "10.1.1.2"
+    node3 = mock.MagicMock(spec=OrchestratorRaftNode)
+    node3.hostname = "ip-10-1-1-3"
+    node3.private_ip = "10.1.1.3"
+    with (
+        mock.patch.object(OrchestratorRaftCluster, "leader", new_callable=mock.PropertyMock, return_value=mock_leader),
+        mock.patch.object(
+            OrchestratorRaftCluster, "nodes", new_callable=mock.PropertyMock, return_value=[node1, node2, node3]
+        ),
+    ):
+        cluster.reconcile()
+    # Stale peer 10.1.1.99 removed
+    mock_leader.remove_peer.assert_called_once()
+    removed_node = mock_leader.remove_peer.call_args[0][0]
+    assert isinstance(removed_node, OrchestratorRaftNode)
+    assert removed_node.peer_addr == "10.1.1.99:10008"
+    # Missing node3 added
+    mock_leader.add_peer.assert_called_once_with(node3)
+
+
 def test_asg_session_propagated():
     """The ASG instance receives the session from the cluster."""
     mock_session = mock.MagicMock()


### PR DESCRIPTION
Raft returns IP addresses (e.g. 10.1.1.1:10008) but leader/peers/reconcile
compared them against EC2 short hostnames (e.g. ip-10-1-1-1), so they never
matched. Build node lookup dicts keyed by both private_ip and hostname.
Also fix DynamoDB integration tests failing with expired AWS credentials:
_has_aws_credentials() now validates with sts.get_caller_identity() instead
of just checking for a non-None credentials object.

Fixes #105
