### PR TITLE
Fix KeyError on private_ip for instances without an IP

### DIFF
--- a/src/infrahouse_core/aws/ec2_instance.py
+++ b/src/infrahouse_core/aws/ec2_instance.py
@@ -164,9 +164,10 @@ class EC2Instance:
     @property
     def private_ip(self):
         """
-        :return: Instance's private IP address
+        :return: Instance's private IP address.
+            Can be None if the instance is in a transitional lifecycle state.
         """
-        return self._describe_instance["PrivateIpAddress"]
+        return self._describe_instance.get("PrivateIpAddress")
 
     @property
     def public_ip(self):

--- a/src/infrahouse_core/orchestrator/raft_cluster.py
+++ b/src/infrahouse_core/orchestrator/raft_cluster.py
@@ -89,7 +89,9 @@ class OrchestratorRaftCluster:
         """
         lookup = {}
         for node in nodes:
-            lookup[node.private_ip] = node
+            ip = node.private_ip
+            if ip is not None:
+                lookup[ip] = node
             lookup[node.hostname] = node
         return lookup
 


### PR DESCRIPTION
EC2Instance.private_ip used dict[] access which raises KeyError when
PrivateIpAddress is absent from the describe response (e.g. during
Pending:Wait or shutting-down). Use .get() to return None instead,
matching the existing public_ip behavior. Skip None IPs in
_node_lookup.

Fixes #107
