### PR TITLE
Skip pending/terminated instances in Raft node discovery

### DIFF
--- a/src/infrahouse_core/orchestrator/raft_cluster.py
+++ b/src/infrahouse_core/orchestrator/raft_cluster.py
@@ -64,9 +64,21 @@ class OrchestratorRaftCluster:
             )
         return self._asg_instance
 
+    _SKIP_LIFECYCLE_STATES = frozenset(
+        {
+            "Pending",
+            "Pending:Wait",
+            "Pending:Proceed",
+            "Terminated",
+        }
+    )
+
     @property
     def nodes(self):
-        """Return an :class:`OrchestratorRaftNode` for each live ASG instance.
+        """Return an :class:`OrchestratorRaftNode` for each queryable ASG instance.
+
+        Instances in early lifecycle states (``Pending``, ``Pending:Wait``, etc.)
+        are excluded because they have no SSM agent or Orchestrator running yet.
 
         :rtype: list[OrchestratorRaftNode]
         """
@@ -77,6 +89,7 @@ class OrchestratorRaftCluster:
                 raft_port=self._raft_port,
             )
             for instance in self._asg.instances
+            if instance.lifecycle_state not in self._SKIP_LIFECYCLE_STATES
         ]
 
     def _node_lookup(self, nodes):

--- a/tests/orchestrator/test_raft_cluster.py
+++ b/tests/orchestrator/test_raft_cluster.py
@@ -13,11 +13,12 @@ from infrahouse_core.orchestrator.raft_cluster import OrchestratorRaftCluster
 from infrahouse_core.orchestrator.raft_node import OrchestratorRaftNode
 
 
-def _mock_asg_instance(private_ip, hostname):
+def _mock_asg_instance(private_ip, hostname, lifecycle_state="InService"):
     """Helper to create a mock ASGInstance."""
     inst = mock.MagicMock()
     inst.private_ip = private_ip
     inst.hostname = hostname
+    inst.lifecycle_state = lifecycle_state
     return inst
 
 
@@ -37,6 +38,22 @@ def test_nodes_from_asg():
         # Each node wraps the original ASGInstance
         assert nodes[0].instance is instances[0]
         assert nodes[1].instance is instances[1]
+
+
+def test_nodes_skips_pending_instances():
+    """nodes excludes instances in Pending states (issue #109)."""
+    cluster = OrchestratorRaftCluster("my-asg", region="us-east-1")
+    instances = [
+        _mock_asg_instance("10.1.1.1", "ip-10-1-1-1", lifecycle_state="InService"),
+        _mock_asg_instance("10.1.1.2", "ip-10-1-1-2", lifecycle_state="Pending:Wait"),
+        _mock_asg_instance("10.1.1.3", "ip-10-1-1-3", lifecycle_state="Terminating:Wait"),
+    ]
+    with mock.patch.object(OrchestratorRaftCluster, "_asg", new_callable=mock.PropertyMock) as mock_asg:
+        mock_asg.return_value.instances = instances
+        nodes = cluster.nodes
+        assert len(nodes) == 2
+        hostnames = {n.hostname for n in nodes}
+        assert hostnames == {"ip-10-1-1-1", "ip-10-1-1-3"}
 
 
 def test_leader_found():


### PR DESCRIPTION
nodes property now excludes ASG instances in Pending, Pending:Wait,
Pending:Proceed, and Terminated states. These instances have no SSM
agent or Orchestrator running, so querying them wastes ~27s on SSM
retries. Terminating:Wait instances are still included since they
may be the current Raft leader.

Fixes #109
