### PR TITLE
Fix _send_command retrying forever on terminated instances (#111)

### DIFF
--- a/src/infrahouse_core/aws/ec2_instance.py
+++ b/src/infrahouse_core/aws/ec2_instance.py
@@ -340,6 +340,12 @@ class EC2Instance:
 
                 except ClientError as e:
                     if e.response["Error"]["Code"] == "InvalidInstanceId":
+                        # Check if the instance is terminated — no point retrying
+                        state = self.state
+                        if state in ("terminated", "shutting-down"):
+                            raise RuntimeError(
+                                f"Instance {self.instance_id} is {state} — SSM will never connect"
+                            ) from e
                         LOG.warning("Instance is not ready yet. Retrying in %d seconds.", delay)
                         sleep(delay)
                         delay = min(delay * 2, 30)  # increase delay exponentially, capped at 30 seconds

--- a/src/infrahouse_core/orchestrator/raft_cluster.py
+++ b/src/infrahouse_core/orchestrator/raft_cluster.py
@@ -123,7 +123,7 @@ class OrchestratorRaftCluster:
         for node in nodes:
             try:
                 leader_addr = node.raft_leader
-            except IHRaftPeerError:
+            except (IHRaftPeerError, TimeoutError, RuntimeError):
                 LOG.warning("Could not reach node %s, skipping.", node.hostname)
                 continue
             if leader_addr is not None:

--- a/tests/aws/ec2_instance/test_send_command.py
+++ b/tests/aws/ec2_instance/test_send_command.py
@@ -23,6 +23,12 @@ def ec2_instance(monkeypatch):
     instance = EC2Instance(instance_id="i-1234567890abcdef", region="us-east-1")
     # Override the ssm_client with a MagicMock to intercept calls.
     instance._ssm_client = MagicMock()
+    # Mock ec2_client so state checks don't hit real AWS (default: pending).
+    mock_ec2 = MagicMock()
+    mock_ec2.describe_instances.return_value = {
+        "Reservations": [{"Instances": [{"State": {"Name": "pending"}}]}]
+    }
+    instance._ec2_client = mock_ec2
     return instance
 
 
@@ -54,9 +60,55 @@ def test_send_command_retry_then_success(ec2_instance):
     assert ec2_instance._ssm_client.send_command.call_count == 2
 
 
-# def test_execute_command():
-#     ec2_instance = EC2Instance()
-#     exec_code, stdout, stderr = ec2_instance.execute_command("echo hello")
-#     assert exec_code == 0
-#     assert stdout == "hello\n"
-#     assert stderr == ""
+def test_send_command_raises_on_terminated_instance(ec2_instance, monkeypatch):
+    """_send_command raises RuntimeError immediately when instance is terminated (issue #111)."""
+    error_response = {"Error": {"Code": "InvalidInstanceId", "Message": "Instance not ready"}}
+    client_error = ClientError(error_response, "send_command")
+    ec2_instance._ssm_client.send_command.side_effect = client_error
+
+    # Mock the ec2_client so that describe_instances reports a terminated state.
+    mock_ec2 = MagicMock()
+    mock_ec2.describe_instances.return_value = {
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "State": {"Name": "terminated"},
+                    }
+                ]
+            }
+        ]
+    }
+    ec2_instance._ec2_client = mock_ec2
+
+    with pytest.raises(RuntimeError, match="terminated"):
+        ec2_instance._send_command("echo hello")
+
+    # Should only attempt send_command once before checking state and raising.
+    assert ec2_instance._ssm_client.send_command.call_count == 1
+
+
+def test_send_command_raises_on_shutting_down_instance(ec2_instance, monkeypatch):
+    """_send_command raises RuntimeError immediately when instance is shutting-down (issue #111)."""
+    error_response = {"Error": {"Code": "InvalidInstanceId", "Message": "Instance not ready"}}
+    client_error = ClientError(error_response, "send_command")
+    ec2_instance._ssm_client.send_command.side_effect = client_error
+
+    mock_ec2 = MagicMock()
+    mock_ec2.describe_instances.return_value = {
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "State": {"Name": "shutting-down"},
+                    }
+                ]
+            }
+        ]
+    }
+    ec2_instance._ec2_client = mock_ec2
+
+    with pytest.raises(RuntimeError, match="shutting-down"):
+        ec2_instance._send_command("echo hello")
+
+    assert ec2_instance._ssm_client.send_command.call_count == 1

--- a/tests/orchestrator/test_raft_cluster.py
+++ b/tests/orchestrator/test_raft_cluster.py
@@ -281,6 +281,40 @@ def test_reconcile_raises_on_remove_error():
             cluster.reconcile()
 
 
+def test_leader_skips_timeout_error():
+    """leader skips nodes that raise TimeoutError (issue #111)."""
+    cluster = OrchestratorRaftCluster("my-asg", region="us-east-1")
+    node1 = mock.MagicMock(spec=OrchestratorRaftNode)
+    node1.hostname = "ip-10-1-1-1"
+    type(node1).raft_leader = mock.PropertyMock(side_effect=TimeoutError("timed out"))
+    node2 = mock.MagicMock(spec=OrchestratorRaftNode)
+    node2.hostname = "ip-10-1-1-2"
+    node2.raft_leader = "ip-10-1-1-2:10008"
+    with mock.patch.object(
+        OrchestratorRaftCluster, "nodes", new_callable=mock.PropertyMock, return_value=[node1, node2]
+    ):
+        leader = cluster.leader
+        assert leader.hostname == "ip-10-1-1-2"
+
+
+def test_leader_skips_runtime_error():
+    """leader skips nodes that raise RuntimeError from terminated instances (issue #111)."""
+    cluster = OrchestratorRaftCluster("my-asg", region="us-east-1")
+    node1 = mock.MagicMock(spec=OrchestratorRaftNode)
+    node1.hostname = "ip-10-1-1-1"
+    type(node1).raft_leader = mock.PropertyMock(
+        side_effect=RuntimeError("Instance i-123 is terminated — SSM will never connect")
+    )
+    node2 = mock.MagicMock(spec=OrchestratorRaftNode)
+    node2.hostname = "ip-10-1-1-2"
+    node2.raft_leader = "ip-10-1-1-2:10008"
+    with mock.patch.object(
+        OrchestratorRaftCluster, "nodes", new_callable=mock.PropertyMock, return_value=[node1, node2]
+    ):
+        leader = cluster.leader
+        assert leader.hostname == "ip-10-1-1-2"
+
+
 def test_leader_found_by_ip():
     """leader matches when Raft returns IP addresses instead of hostnames (issue #105)."""
     cluster = OrchestratorRaftCluster("my-asg", region="us-east-1")


### PR DESCRIPTION
Check instance state inside the InvalidInstanceId retry loop in
_send_command. If the instance is terminated or shutting-down, raise
RuntimeError immediately instead of retrying until timeout.

Also catch TimeoutError and RuntimeError in OrchestratorRaftCluster.leader
so terminated nodes are skipped gracefully during leader discovery.
