### PR TITLE
Fix get_aws_session() ignoring aws_profile when SSO token is valid (#113)

### DIFF
--- a/src/infrahouse_core/aws/__init__.py
+++ b/src/infrahouse_core/aws/__init__.py
@@ -130,7 +130,7 @@ def get_aws_session(aws_config: AWSConfig, aws_profile: str, aws_region: str) ->
         LOG.info("Available profiles:\n\t%s", "\n\t".join(aws_config.profiles))
         sys.exit(1)
 
-    return boto3.Session(region_name=aws_region)
+    return boto3.Session(region_name=aws_region, profile_name=aws_profile)
 
 
 def get_session(role_arn=None, region=None, session_name=None):

--- a/tests/aws/test_get_aws_session.py
+++ b/tests/aws/test_get_aws_session.py
@@ -1,0 +1,56 @@
+"""Tests for get_aws_session() profile handling (issue #113)."""
+
+from unittest import mock
+
+from infrahouse_core.aws import get_aws_session
+from infrahouse_core.aws.config import AWSConfig
+
+
+def test_get_aws_session_passes_profile_on_success_path():
+    """
+    When get_caller_identity() succeeds (SSO token already valid),
+    get_aws_session() must return a session with the requested profile_name.
+
+    Regression test for https://github.com/infrahouse/infrahouse-core/issues/113
+    """
+    mock_config = mock.MagicMock(spec=AWSConfig)
+    mock_config.profiles = ["profile-a", "profile-b"]
+
+    with mock.patch("infrahouse_core.aws.get_aws_client") as mock_get_client:
+        # Simulate successful get_caller_identity (SSO token is valid)
+        mock_sts = mock.MagicMock()
+        mock_sts.get_caller_identity.return_value = {"Arn": "arn:aws:iam::123456789012:user/test"}
+        mock_get_client.return_value = mock_sts
+
+        with mock.patch("infrahouse_core.aws.boto3.Session") as mock_session_cls:
+            mock_session = mock.MagicMock()
+            mock_session_cls.return_value = mock_session
+
+            result = get_aws_session(mock_config, "profile-a", "us-west-2")
+
+            # The key assertion: profile_name must be passed
+            mock_session_cls.assert_called_once_with(region_name="us-west-2", profile_name="profile-a")
+            assert result is mock_session
+
+
+def test_get_aws_session_passes_default_profile_when_none():
+    """
+    When aws_profile is None and 'default' exists in config,
+    the session should use 'default' as profile_name.
+    """
+    mock_config = mock.MagicMock(spec=AWSConfig)
+    mock_config.profiles = ["default", "other"]
+
+    with mock.patch("infrahouse_core.aws.get_aws_client") as mock_get_client:
+        mock_sts = mock.MagicMock()
+        mock_sts.get_caller_identity.return_value = {"Arn": "arn:aws:iam::123456789012:user/test"}
+        mock_get_client.return_value = mock_sts
+
+        with mock.patch("infrahouse_core.aws.boto3.Session") as mock_session_cls:
+            mock_session = mock.MagicMock()
+            mock_session_cls.return_value = mock_session
+
+            result = get_aws_session(mock_config, None, "us-east-1")
+
+            mock_session_cls.assert_called_once_with(region_name="us-east-1", profile_name="default")
+            assert result is mock_session


### PR DESCRIPTION
## Summary
- `get_aws_session()` dropped `profile_name` on the success path (when SSO token was already cached), causing all `ih-*` CLI tools to ignore `--aws-profile`
- Added `profile_name=aws_profile` to the `boto3.Session()` call on the success path
- Added regression tests for both explicit profile and default profile cases

Fixes #113                                                                                                                                                                                                         
## Test plan                                                                                                                                                                                                       
- [x] New test `test_get_aws_session_passes_profile_on_success_path` fails before fix, passes after                                                                                                                
- [x] New test `test_get_aws_session_passes_default_profile_when_none` passes                      
- [x] All existing session/auth tests pass                                                      

