### PR TITLE
Fix OOM in GitHubActions.runners / find_runners_by_label (#136)

### DIFF
--- a/.claude/plans/github-runners-memory.md
+++ b/.claude/plans/github-runners-memory.md
@@ -1,0 +1,214 @@
+# Plan: Fix OOM in GitHubActions.runners / find_runners_by_label
+
+## Context
+
+GitHub issue [infrahouse/infrahouse-core#136](https://github.com/infrahouse/infrahouse-core/issues/136):
+`GitHubActions.runners` (property) and `find_runners_by_label()` in `src/infrahouse_core/github.py`
+load the entire org's runner list into memory before returning. In a 128 MB Lambda with a large
+org, this causes `Runtime.OutOfMemory`.
+
+Current memory cost per call:
+
+1. `_get_github_runners()` builds a Python list with every page's `runners[]` merged (`runners.extend(data["runners"])`).
+2. `runners` wraps that list into a second full list of `GitHubActionsRunner` objects via list comprehension.
+3. `find_runners_by_label()` calls `self.runners` and materializes a third list via list comprehension.
+
+So for N org runners, peak live objects are ~3N before the caller ever starts processing. Fix is to
+stream pages and yield one runner at a time so memory is O(1) (or O(page_size), which is bounded by
+the GitHub API — max 100 per page).
+
+## Step 1 — Write a failing test that reproduces the memory problem
+
+File: `tests/github/test_runners_memory.py` (new file).
+
+The test must demonstrate that the current implementation materializes all runners before the
+caller can process any of them. The cleanest way to prove this without measuring RSS is to assert
+that the iteration is **lazy** — i.e. that consuming only the first element from
+`find_runners_by_label()` should not require the HTTP GET for later pages to have completed.
+
+### Test design
+
+Patch `infrahouse_core.github.get` with a `side_effect` function that serves paginated responses.
+Each page's mock response exposes a `.links` dict pointing to the next page. Crucially, the mock
+tracks how many pages have been fetched in a shared counter.
+
+The test then:
+
+1. Creates a `GitHubActions` instance with a `GitHubAuth` stub.
+2. Calls `find_runner_by_label("alpha")` where `"alpha"` is on a runner present in **page 1**.
+3. Asserts that `fetched_pages == 1` — i.e. the implementation short-circuited after finding the
+   match on the first page and never paged through the rest.
+
+Under the current code, `find_runner_by_label` calls `self.runners`, which calls
+`_get_github_runners()`, which eagerly walks every page before returning. The counter will
+therefore be `== total_pages` (e.g. 5), not 1, and the assertion fails.
+
+A second test covers `find_runners_by_label` (plural): set up 5 pages where the "alpha" label
+appears on page 1 and page 3 only. Consume **only the first element** of the result by calling
+`next(iter(gha.find_runners_by_label("alpha")))` and assert that `fetched_pages == 1`. This test
+will fail under the current implementation (which returns a `list`, forcing all pages to be
+fetched) and pass once the method becomes a generator. It also documents the new contract: the
+method returns an iterator, not a list.
+
+A third test is a straightforward correctness check: consume the full iterator and assert the
+returned runners' IDs match the expected set across all pages. This guards against the generator
+fix accidentally dropping or double-yielding runners.
+
+### Test skeleton
+
+```python
+from unittest import mock
+import pytest
+from infrahouse_core.github import GitHubActions, GitHubAuth
+
+
+def _make_page(runners, next_url=None):
+    resp = mock.Mock()
+    resp.json.return_value = {"runners": runners}
+    resp.links = {"next": {"url": next_url}} if next_url else {}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+@pytest.fixture
+def paginated_get():
+    fetched = {"count": 0}
+
+    def _runner(i, labels):
+        return {"id": i, "name": f"r{i}", "os": "linux", "status": "online",
+                "busy": False, "labels": [{"id": 1, "name": l} for l in labels]}
+
+    pages = [
+        [_runner(1, ["alpha"]), _runner(2, ["beta"])],
+        [_runner(3, ["gamma"])],
+        [_runner(4, ["alpha"]), _runner(5, ["delta"])],
+        [_runner(6, ["epsilon"])],
+        [_runner(7, ["zeta"])],
+    ]
+    urls = [f"https://api.github.com/p{i}" for i in range(len(pages))]
+
+    def side_effect(url, headers=None, timeout=None):
+        fetched["count"] += 1
+        idx = urls.index(url) if url in urls else 0
+        next_url = urls[idx + 1] if idx + 1 < len(pages) else None
+        return _make_page(pages[idx], next_url)
+
+    with mock.patch("infrahouse_core.github.get", side_effect=side_effect) as m:
+        # Seed first URL (the initial fetch uses the org URL, not urls[0])
+        yield m, fetched, urls, pages
+
+
+def test_find_runner_by_label_is_lazy(paginated_get):
+    _, fetched, _, _ = paginated_get
+    gha = GitHubActions(GitHubAuth("t", "org"))
+    runner = gha.find_runner_by_label("alpha")
+    assert runner is not None
+    assert fetched["count"] == 1  # fails today — eager paging fetches all 5
+```
+
+Note: the real initial URL is `https://api.github.com/orgs/{org}/actions/runners`, so the
+`side_effect` will need a small tweak to treat that as "page 0" — either by seeding `urls[0]` to
+that exact string or by matching on a path prefix.
+
+Run `pytest tests/github/test_runners_memory.py -xvvs` and confirm these tests **fail** against
+`main` before moving on.
+
+## Step 2 — Implementation
+
+File: `src/infrahouse_core/github.py`.
+
+### 2a. `_get_github_runners` → generator
+
+```python
+def _get_github_runners(self) -> Iterator[dict]:
+    url = f"https://api.github.com/orgs/{self._github.org}/actions/runners"
+    while url:
+        response = get(url, headers=self._github_headers, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        for runner in data["runners"]:
+            yield runner
+        url = response.links.get("next", {}).get("url")
+```
+
+One page is held in memory at a time. Add `from typing import Iterator` to the imports.
+
+### 2b. `GitHubActions.runners` → generator
+
+```python
+@property
+def runners(self) -> Iterator[GitHubActionsRunner]:
+    for r in self._get_github_runners():
+        yield GitHubActionsRunner(r["id"], self._github, runner_data=r)
+```
+
+**Type-hint change is a breaking change** at the signature level (was `List[...]`, now
+`Iterator[...]`). Callers that do `len(gha.runners)` or `gha.runners[0]` will break. Grep the
+codebase for `.runners` usage — the only in-tree call sites are `find_runner_by_label` and
+`find_runners_by_label`, both of which iterate, so they are safe. Any external repo consuming
+the library that materialized the list needs to call `list(gha.runners)` explicitly; mention
+this in the PR description as a minor breaking change.
+
+### 2c. `find_runner_by_label` — already correct
+
+It already uses `next((... for runner in self.runners ...), None)`, so once `runners` is a
+generator, it becomes lazy automatically. No code change needed, but the new behavior (stops
+paging at first match) is what makes the first test pass.
+
+### 2d. `find_runners_by_label` → generator
+
+```python
+def find_runners_by_label(self, label: str) -> Iterator[GitHubActionsRunner]:
+    for runner in self.runners:
+        if label in runner.labels:
+            yield runner
+```
+
+Return type changes from `List[GitHubActionsRunner]` to `Iterator[GitHubActionsRunner]`.
+Same breaking-change caveat as `runners` — grep for call sites. Known in-tree call site:
+`tests/github/test_find_runners_by_label.py` does `len(result)` and `result == []`, which will
+break with a generator. Update that test to wrap with `list(...)`:
+
+```python
+result = list(gha_instance.find_runners_by_label("any"))
+```
+
+Two spots in `test_find_runners_by_label.py` need this adjustment.
+
+## Step 3 — Verify
+
+Re-run the new memory tests:
+
+```bash
+pytest tests/github/test_runners_memory.py -xvvs
+```
+
+All three should now pass (`fetched["count"] == 1` for the short-circuit tests; correctness test
+yields all runners across pages).
+
+Re-run the full github test module to ensure no regression:
+
+```bash
+pytest tests/github/ -xvvs
+```
+
+Then the whole suite:
+
+```bash
+make test
+```
+
+## Step 4 — Docs / linting
+
+- Update the docstring example in `GitHubActions` class: the `for runner in gha.runners` loop
+  still works unchanged, so no doc change needed there. But add a one-line note that `runners`
+  and `find_runners_by_label` return iterators — callers should iterate or wrap with `list()`.
+- Run `make lint` before committing.
+
+## Out of scope
+
+- Per-runner boto3 client reuse in `ASGInstance` (the issue mentions it as a contributing factor,
+  but it lives outside `github.py` and is a separate optimization).
+- Adding a `page_size` knob to `_get_github_runners` — the GitHub default (30) is already small;
+  changing it is an orthogonal tuning exercise.
+- Caching. Do **not** add caching to the generator — that would re-introduce the memory problem.

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -129,6 +129,13 @@ Typical lazy usage::
             continue
         gha.deregister_runner(runner)
 
+Deregistering while iterating is safe: ``deregister_runner`` issues an
+independent ``DELETE /orgs/{org}/actions/runners/{id}`` request and does not
+mutate the paginated list response that the iterator is currently reading
+from. Contrast this with iterating a local list and mutating it in place,
+which Python forbids — the GitHub pagination cursor lives server-side and
+is advanced only when the iterator asks for the next page.
+
 
 Caching Behaviour
 =================

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -102,6 +102,34 @@ first API call is made::
 for CloudTrail auditing.  You can override this with the ``session_name`` parameter.
 
 
+GitHub Runner Iteration
+=======================
+
+``GitHubActions.runners`` and ``GitHubActions.find_runners_by_label()`` return
+**iterators**, not lists. They stream pages from the GitHub API lazily and yield
+one ``GitHubActionsRunner`` at a time, so memory usage stays bounded to a
+single page (~100 runners) regardless of organization size.
+
+This matters in memory-constrained environments — for example, a 128 MB AWS
+Lambda function running against a large organization would previously OOM
+because ``runners`` materialized the entire list before returning. With the
+iterator contract, ``find_runner_by_label()`` also short-circuits: once a match
+is found on the current page, subsequent pages are never fetched.
+
+Callers that need a materialized collection should wrap the result with
+``list()``::
+
+    all_runners = list(gha.runners)
+    alphas = list(gha.find_runners_by_label("alpha"))
+
+Typical lazy usage::
+
+    for runner in gha.runners:
+        if runner.busy:
+            continue
+        gha.deregister_runner(runner)
+
+
 Caching Behaviour
 =================
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -105,6 +105,51 @@ All resource classes accept ``role_arn`` for cross-account operations::
     instance = EC2Instance("i-abc123", role_arn="arn:aws:iam::123456789012:role/Admin")
 
 
+Breaking Changes
+================
+
+GitHubActions: ``runners`` / ``find_runners_by_label`` are now iterators
+------------------------------------------------------------------------
+
+**Changed in:** v1.0.0
+
+``GitHubActions.runners`` and ``GitHubActions.find_runners_by_label()`` now
+return ``Iterator[GitHubActionsRunner]`` instead of ``List[GitHubActionsRunner]``.
+Pages are fetched from the GitHub API lazily as the iterator advances, keeping
+memory usage bounded to a single API page. This fixes OOM crashes in 128 MB
+AWS Lambda functions running against large organizations.
+
+Code that iterated over the results keeps working unchanged::
+
+    for runner in gha.runners:
+        ...
+
+    for runner in gha.find_runners_by_label("instance_id:i-abc123"):
+        ...
+
+Code that relied on list semantics must wrap with ``list()``:
+
+Before::
+
+    all_runners = gha.runners
+    count = len(all_runners)
+    first = all_runners[0]
+
+    matches = gha.find_runners_by_label("alpha")
+    if matches == []:
+        ...
+
+After::
+
+    all_runners = list(gha.runners)
+    count = len(all_runners)
+    first = all_runners[0]
+
+    matches = list(gha.find_runners_by_label("alpha"))
+    if not matches:
+        ...
+
+
 Deprecated Parameters
 =====================
 

--- a/src/infrahouse_core/github.py
+++ b/src/infrahouse_core/github.py
@@ -4,7 +4,7 @@ GitHub Actions
 
 from dataclasses import dataclass
 from logging import getLogger
-from typing import List, Optional
+from typing import Iterator, List, Optional
 
 from cached_property import cached_property_with_ttl
 from github import GithubIntegration
@@ -184,7 +184,7 @@ class GitHubActions:
         # Store a registration token in Secrets Manager
         gha.ensure_registration_token("my-runner-token")
 
-        # List runners and find one by label
+        # Iterate over runners (lazy — one API page at a time)
         for runner in gha.runners:
             print(runner.name, runner.status)
 
@@ -194,6 +194,14 @@ class GitHubActions:
 
         # Clean up the token
         gha.ensure_registration_token("my-runner-token", present=False)
+
+    .. note::
+        ``runners`` and ``find_runners_by_label()`` return iterators, not lists.
+        They fetch subsequent GitHub API pages only as the iterator advances, so
+        memory usage stays bounded to one page (~100 runners) regardless of
+        organization size. This is important in memory-constrained environments
+        such as 128 MB AWS Lambda functions. Callers that need a materialized
+        collection should wrap the result with ``list()``.
     """
 
     def __init__(self, github: GitHubAuth, region: str = None, role_arn: str = None):
@@ -228,14 +236,19 @@ class GitHubActions:
         return response.json()["token"]
 
     @property
-    def runners(self) -> List[GitHubActionsRunner]:
+    def runners(self) -> Iterator[GitHubActionsRunner]:
         """
-        Retrieve a list of all self-hosted runners for the organization.
+        Iterate over all self-hosted runners for the organization.
 
-        :return: A list of GitHubActionsRunner objects.
-        :rtype: list[GitHubActionsRunner]
+        Yields runners one at a time, fetching subsequent API pages only as
+        the iterator advances. Keeps memory usage bounded to one page when
+        running in memory-constrained environments (e.g. Lambda).
+
+        :return: An iterator of GitHubActionsRunner objects.
+        :rtype: Iterator[GitHubActionsRunner]
         """
-        return [GitHubActionsRunner(r["id"], self._github, runner_data=r) for r in self._get_github_runners()]
+        for r in self._get_github_runners():
+            yield GitHubActionsRunner(r["id"], self._github, runner_data=r)
 
     def deregister_runner(self, runner: GitHubActionsRunner):
         """
@@ -278,21 +291,22 @@ class GitHubActions:
         """
         return next((runner for runner in self.runners if label in runner.labels), None)
 
-    def find_runners_by_label(self, label: str) -> List[GitHubActionsRunner]:
+    def find_runners_by_label(self, label: str) -> Iterator[GitHubActionsRunner]:
         """
-        Find all runners that have the specified label.
+        Yield all runners that have the specified label.
 
-        This method iterates over all available runners and collects
-        those that contain the specified label in their list of labels.
+        Iterates lazily over the organization's runners, fetching subsequent
+        API pages only as the caller advances the iterator. Callers that need
+        a materialized collection should wrap the result with ``list()``.
 
         :param label: The label to search for.
         :type label: str
-        :return: A list of GitHubActionsRunner objects that match the label,
-                 or an empty list if none are found.
-        :rtype: List[GitHubActionsRunner]
+        :return: An iterator of GitHubActionsRunner objects that match the label.
+        :rtype: Iterator[GitHubActionsRunner]
         """
-        # Filter runners by checking if the label is present in each runner's labels
-        return [runner for runner in self.runners if label in runner.labels]
+        for runner in self.runners:
+            if label in runner.labels:
+                yield runner
 
     @property
     def _github_headers(self) -> dict:
@@ -302,22 +316,25 @@ class GitHubActions:
             "X-GitHub-Api-Version": "2022-11-28",
         }
 
-    def _get_github_runners(self) -> List[dict]:
+    def _get_github_runners(self) -> Iterator[dict]:
         """
-        Internal method to retrieve raw runner data from the GitHub API.
+        Yield raw runner metadata from the GitHub API one page at a time.
 
-        :return: A list of runner metadata dictionaries.
-        :rtype: list[dict]
+        Only one page of runner dicts is held in memory at a time. This keeps
+        ``runners`` and ``find_runners_by_label`` O(page_size) rather than
+        O(total_runners), which matters in constrained environments such as
+        128 MB Lambda functions.
+
+        :return: An iterator of runner metadata dictionaries.
+        :rtype: Iterator[dict]
         """
-        runners = []
         url = f"https://api.github.com/orgs/{self._github.org}/actions/runners"
         while url:
             response = get(url, headers=self._github_headers, timeout=10)
             response.raise_for_status()
             data = response.json()
-            runners.extend(data["runners"])
+            yield from data["runners"]
             url = response.links.get("next", {}).get("url")
-        return runners
 
     def _ensure_present_secret(self, registration_token_secret):
         """

--- a/src/infrahouse_core/github.py
+++ b/src/infrahouse_core/github.py
@@ -244,16 +244,34 @@ class GitHubActions:
         the iterator advances. Keeps memory usage bounded to one page when
         running in memory-constrained environments (e.g. Lambda).
 
+        Each access to this property returns a **new independent generator**.
+        Iterating it consumes the generator; a second ``for r in gha.runners``
+        loop will replay the GitHub API calls from scratch. If you need to
+        iterate the same set of runners more than once, wrap the first access
+        with ``list()`` to materialize the results::
+
+            snapshot = list(gha.runners)
+            busy = [r for r in snapshot if r.busy]
+            idle = [r for r in snapshot if not r.busy]
+
         :return: An iterator of GitHubActionsRunner objects.
         :rtype: Iterator[GitHubActionsRunner]
         """
-        for r in self._get_github_runners():
-            yield GitHubActionsRunner(r["id"], self._github, runner_data=r)
+        yield from (GitHubActionsRunner(r["id"], self._github, runner_data=r) for r in self._get_github_runners())
 
     def deregister_runner(self, runner: GitHubActionsRunner):
         """
-        De-register a runner from the GitHub organization.
+        De-register a self-hosted runner from the GitHub organization.
 
+        Issues ``DELETE /orgs/{org}/actions/runners/{runner_id}`` and raises
+        if GitHub returns a non-2xx response. The caller is responsible for
+        stopping the runner process and terminating its host; this method
+        only removes GitHub's record of the runner.
+
+        :param runner: The runner to de-register.
+        :type runner: GitHubActionsRunner
+        :raises requests.HTTPError: If the GitHub API returns a non-2xx status
+            (for example, 404 if the runner was already removed).
         """
         response = delete(
             f"https://api.github.com/orgs/{self._github.org}/actions/runners/{runner.runner_id}",
@@ -304,9 +322,7 @@ class GitHubActions:
         :return: An iterator of GitHubActionsRunner objects that match the label.
         :rtype: Iterator[GitHubActionsRunner]
         """
-        for runner in self.runners:
-            if label in runner.labels:
-                yield runner
+        yield from (runner for runner in self.runners if label in runner.labels)
 
     @property
     def _github_headers(self) -> dict:
@@ -327,13 +343,20 @@ class GitHubActions:
 
         :return: An iterator of runner metadata dictionaries.
         :rtype: Iterator[dict]
+        :raises ValueError: If a paginated response is missing the ``runners`` key.
         """
         url = f"https://api.github.com/orgs/{self._github.org}/actions/runners"
         while url:
             response = get(url, headers=self._github_headers, timeout=10)
             response.raise_for_status()
             data = response.json()
-            yield from data["runners"]
+            runners_page = data.get("runners")
+            if runners_page is None:
+                raise ValueError(
+                    f"Unexpected GitHub API response from {url} — 'runners' key missing. "
+                    f"Keys present: {list(data.keys())}"
+                )
+            yield from runners_page
             url = response.links.get("next", {}).get("url")
 
     def _ensure_present_secret(self, registration_token_secret):

--- a/tests/github/test_find_runners_by_label.py
+++ b/tests/github/test_find_runners_by_label.py
@@ -55,12 +55,12 @@ def gha_instance(runner_1, runner_2, runner_3):
 
 
 def test_find_runners_by_label_empty(gha_instance):
-    # When there are no runners, the method should return an empty list.
-    result = gha_instance.find_runners_by_label("any")
+    # When there are no runners, the method should yield nothing.
+    result = list(gha_instance.find_runners_by_label("any"))
     assert result == []
 
 
 def test_find_runners_by_label_found(gha_instance):
-    # Should return only those runners that include the "alpha" label.
-    result = gha_instance.find_runners_by_label("alpha")
+    # Should yield only those runners that include the "alpha" label.
+    result = list(gha_instance.find_runners_by_label("alpha"))
     assert len(result) == 2

--- a/tests/github/test_find_runners_by_label.py
+++ b/tests/github/test_find_runners_by_label.py
@@ -54,8 +54,10 @@ def gha_instance(runner_1, runner_2, runner_3):
         yield GitHubActions(mock.MagicMock())
 
 
-def test_find_runners_by_label_empty(gha_instance):
-    # When there are no runners, the method should yield nothing.
+def test_find_runners_by_label_no_match(gha_instance):
+    # When no runner carries the requested label, the method yields nothing.
+    # (For the real empty-org path — GitHub API returning {"runners": []} —
+    # see test_get_github_runners_empty_org in test_runners_memory.py.)
     result = list(gha_instance.find_runners_by_label("any"))
     assert result == []
 

--- a/tests/github/test_runners_memory.py
+++ b/tests/github/test_runners_memory.py
@@ -1,0 +1,106 @@
+"""
+Regression tests for https://github.com/infrahouse/infrahouse-core/issues/136.
+
+These tests assert that GitHubActions.runners / find_runner_by_label /
+find_runners_by_label iterate lazily over paginated GitHub API responses
+instead of materializing every page before returning.
+"""
+
+from unittest import mock
+
+import pytest
+
+from infrahouse_core.github import GitHubActions, GitHubAuth
+
+ORG = "test-org"
+BASE_URL = f"https://api.github.com/orgs/{ORG}/actions/runners"
+
+
+def _runner(runner_id, label_names):
+    return {
+        "id": runner_id,
+        "name": f"runner{runner_id}",
+        "os": "linux",
+        "status": "online",
+        "busy": False,
+        "labels": [{"id": i, "name": n, "type": "custom"} for i, n in enumerate(label_names)],
+    }
+
+
+def _make_response(runners, next_url):
+    resp = mock.Mock()
+    resp.json.return_value = {"runners": runners}
+    resp.links = {"next": {"url": next_url}} if next_url else {}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+@pytest.fixture
+def paginated_get():
+    """
+    Simulate 5 pages of GitHub runners. Page 1 has the "alpha" label; page 3
+    also has "alpha". Pages 2/4/5 do not. The fixture tracks how many pages
+    have been fetched so tests can assert laziness.
+    """
+    pages = [
+        [_runner(1, ["alpha"]), _runner(2, ["beta"])],
+        [_runner(3, ["gamma"])],
+        [_runner(4, ["alpha"]), _runner(5, ["delta"])],
+        [_runner(6, ["epsilon"])],
+        [_runner(7, ["zeta"])],
+    ]
+    page_urls = [BASE_URL] + [f"https://api.github.com/p{i}" for i in range(1, len(pages))]
+    state = {"fetched": 0}
+
+    def side_effect(url, headers=None, timeout=None):
+        state["fetched"] += 1
+        idx = page_urls.index(url)
+        next_url = page_urls[idx + 1] if idx + 1 < len(pages) else None
+        return _make_response(pages[idx], next_url)
+
+    with mock.patch("infrahouse_core.github.get", side_effect=side_effect):
+        yield state, pages
+
+
+def test_find_runner_by_label_stops_at_first_page(paginated_get):
+    """
+    A single match on page 1 must not cause pages 2-5 to be fetched.
+    Fails under the current eager implementation because _get_github_runners
+    walks every page before returning.
+    """
+    state, _ = paginated_get
+    gha = GitHubActions(GitHubAuth("test-token", ORG))
+
+    runner = gha.find_runner_by_label("alpha")
+
+    assert runner is not None
+    assert runner.runner_id == 1
+    assert state["fetched"] == 1
+
+
+def test_find_runners_by_label_is_lazy(paginated_get):
+    """
+    Consuming only the first element of find_runners_by_label must not
+    force all pages to be fetched. This locks in the generator contract.
+    """
+    state, _ = paginated_get
+    gha = GitHubActions(GitHubAuth("test-token", ORG))
+
+    first = next(iter(gha.find_runners_by_label("alpha")))
+
+    assert first.runner_id == 1
+    assert state["fetched"] == 1
+
+
+def test_find_runners_by_label_yields_all_matches(paginated_get):
+    """
+    Correctness guard: a full consumption must yield every matching runner
+    across all pages with no duplicates or drops.
+    """
+    state, pages = paginated_get
+    gha = GitHubActions(GitHubAuth("test-token", ORG))
+
+    matches = list(gha.find_runners_by_label("alpha"))
+
+    assert [r.runner_id for r in matches] == [1, 4]
+    assert state["fetched"] == len(pages)

--- a/tests/github/test_runners_memory.py
+++ b/tests/github/test_runners_memory.py
@@ -9,6 +9,7 @@ instead of materializing every page before returning.
 from unittest import mock
 
 import pytest
+from requests import HTTPError
 
 from infrahouse_core.github import GitHubActions, GitHubAuth
 
@@ -54,6 +55,8 @@ def paginated_get():
 
     def side_effect(url, headers=None, timeout=None):
         state["fetched"] += 1
+        if url not in page_urls:
+            pytest.fail(f"Unexpected URL requested by _get_github_runners: {url!r}")
         idx = page_urls.index(url)
         next_url = page_urls[idx + 1] if idx + 1 < len(pages) else None
         return _make_response(pages[idx], next_url)
@@ -92,6 +95,21 @@ def test_find_runners_by_label_is_lazy(paginated_get):
     assert state["fetched"] == 1
 
 
+def test_runners_yields_all_across_all_pages(paginated_get):
+    """
+    Direct end-to-end correctness anchor for the ``runners`` property: all
+    7 runner IDs across all 5 pages must be yielded exactly once, in order,
+    and all 5 pages must be fetched.
+    """
+    state, pages = paginated_get
+    gha = GitHubActions(GitHubAuth("test-token", ORG))
+
+    runner_ids = [r.runner_id for r in gha.runners]
+
+    assert runner_ids == [1, 2, 3, 4, 5, 6, 7]
+    assert state["fetched"] == len(pages)
+
+
 def test_find_runners_by_label_yields_all_matches(paginated_get):
     """
     Correctness guard: a full consumption must yield every matching runner
@@ -104,3 +122,61 @@ def test_find_runners_by_label_yields_all_matches(paginated_get):
 
     assert [r.runner_id for r in matches] == [1, 4]
     assert state["fetched"] == len(pages)
+
+
+def test_get_github_runners_raises_on_missing_runners_key():
+    """
+    If the GitHub API returns a response without the ``runners`` key,
+    ``_get_github_runners`` must fail fast with a ValueError that names
+    the keys that *were* present, rather than bubbling up a KeyError
+    from somewhere deep in the iteration.
+    """
+    bogus = mock.Mock()
+    bogus.json.return_value = {"total_count": 0}  # no "runners" key
+    bogus.links = {}
+    bogus.raise_for_status.return_value = None
+
+    with mock.patch("infrahouse_core.github.get", return_value=bogus):
+        gha = GitHubActions(GitHubAuth("test-token", ORG))
+        with pytest.raises(ValueError, match="'runners' key missing"):
+            list(gha.runners)
+
+
+def test_http_error_on_second_page_raises():
+    """
+    Page 1 succeeds and its runners are yielded to the caller. Page 2 then
+    returns a 5xx — the generator must propagate the HTTPError on the next
+    advance instead of swallowing it or silently truncating the iteration.
+    """
+    page1 = _make_response([_runner(1, ["alpha"])], next_url="https://api.github.com/p1")
+    page2 = mock.Mock()
+    page2.raise_for_status.side_effect = HTTPError("503 Service Unavailable")
+
+    responses = iter([page1, page2])
+
+    with mock.patch("infrahouse_core.github.get", side_effect=lambda *a, **kw: next(responses)):
+        gha = GitHubActions(GitHubAuth("test-token", ORG))
+        gen = iter(gha.runners)
+
+        first = next(gen)
+        assert first.runner_id == 1
+
+        with pytest.raises(HTTPError):
+            next(gen)
+
+
+def test_get_github_runners_empty_org():
+    """
+    An org with zero runners returns ``{"runners": []}`` and must yield
+    nothing without raising. Guards against regressing the empty-org path.
+    """
+    empty = mock.Mock()
+    empty.json.return_value = {"runners": []}
+    empty.links = {}
+    empty.raise_for_status.return_value = None
+
+    with mock.patch("infrahouse_core.github.get", return_value=empty):
+        gha = GitHubActions(GitHubAuth("test-token", ORG))
+        assert list(gha.runners) == []
+        assert gha.find_runner_by_label("anything") is None
+        assert list(gha.find_runners_by_label("anything")) == []


### PR DESCRIPTION
## Summary

- Converts `GitHubActions.runners`, `find_runners_by_label()`, and `_get_github_runners()` into lazy iterators so memory usage stays bounded to one GitHub API page instead of the full organization runner list.
- `find_runner_by_label()` now short-circuits as soon as a match is found — no more paging through the entire org.
- Fixes #136 (Lambda `Runtime.OutOfMemory` at 128 MB on large orgs).

## Breaking change

`GitHubActions.runners` and `find_runners_by_label()` now return `Iterator[GitHubActionsRunner]` instead of `List[GitHubActionsRunner]`. Code that iterates (`for r in gha.runners`) keeps working unchanged. Code that relies on list semantics (`len()`, indexing, `== []`) must wrap with `list(...)`. Migration guide updated in `docs/migration.rst`.

## Test plan

- [x] New regression tests in `tests/github/test_runners_memory.py` reproduce the bug:
  - `test_find_runner_by_label_stops_at_first_page` — asserts only 1 page is fetched when the match is on page 1 (was fetching all 5).
  - `test_find_runners_by_label_is_lazy` — asserts consuming only the first match doesn't force all pages to be fetched.
  - `test_find_runners_by_label_yields_all_matches` — correctness guard across all pages.
- [x] Existing `tests/github/test_find_runners_by_label.py` updated to wrap results with `list(...)` for the new iterator contract.
- [x] Full suite: 554 passed, 2 skipped.
- [x] `make lint` clean (pylint 10.00/10).
- [x] `make docs` builds without warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)