### PR TITLE
Add tag management helpers to AWSResource (#139)

### DIFF
--- a/src/infrahouse_core/aws/base.py
+++ b/src/infrahouse_core/aws/base.py
@@ -69,3 +69,82 @@ class AWSResource(ABC):
     @abstractmethod
     def delete(self) -> None:
         """Delete the resource."""
+
+    # -- Tag helpers ---------------------------------------------------------
+    #
+    # The default implementations use the AWS-wide generic tagging API
+    # (``list_tags_for_resource`` / ``tag_resource`` / ``untag_resource``),
+    # which covers CloudWatch Logs, RDS, Lambda, KMS, Secrets Manager, SNS,
+    # SQS, Step Functions, and many other services.  Subclasses whose
+    # service uses a different tag API (EC2 ``create_tags``, S3
+    # ``put_bucket_tagging``, IAM ``tag_role``, etc.) should override these
+    # methods.  All subclasses that want tag support must implement
+    # :attr:`arn`.
+
+    @property
+    def arn(self) -> str:
+        """Return the ARN of this resource.
+
+        Subclasses must override this to enable the generic tag helpers.
+
+        :raises NotImplementedError: if the subclass has not implemented ``arn``.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not implement arn")
+
+    @property
+    def tags(self) -> dict:
+        """Return current tags as a ``{key: value}`` dict.
+
+        Uses the generic ``list_tags_for_resource`` API.  Override in
+        subclasses whose service uses a different tagging API.
+        """
+        response = self._client.list_tags_for_resource(resourceArn=self.arn)
+        return response.get("tags", {})
+
+    def set_tag(self, key: str, value: str) -> bool:
+        """Set a single tag on this resource.
+
+        Idempotent: if the tag is already set to ``value``, no API call is
+        made.
+
+        :param key: Tag key.
+        :param value: Tag value.
+        :returns: ``True`` if the tag was written, ``False`` if it was
+            already current.
+        """
+        if self.tags.get(key) == value:
+            return False
+        self._client.tag_resource(resourceArn=self.arn, tags={key: value})
+        LOG.info("Set tag %s=%s on %s", key, value, self.arn)
+        return True
+
+    def set_tags(self, tags: dict) -> int:
+        """Set multiple tags on this resource.
+
+        Idempotent: tags that already have the requested value are skipped.
+
+        :param tags: Mapping of tag keys to values.
+        :returns: Number of tags actually written.
+        """
+        current = self.tags
+        to_write = {k: v for k, v in tags.items() if current.get(k) != v}
+        if not to_write:
+            return 0
+        self._client.tag_resource(resourceArn=self.arn, tags=to_write)
+        LOG.info("Set %d tag(s) on %s", len(to_write), self.arn)
+        return len(to_write)
+
+    def remove_tag(self, key: str) -> bool:
+        """Remove a single tag from this resource.
+
+        Idempotent: no-op if the tag is not currently set.
+
+        :param key: Tag key to remove.
+        :returns: ``True`` if the tag was present and removed, ``False``
+            if it was already absent.
+        """
+        if key not in self.tags:
+            return False
+        self._client.untag_resource(resourceArn=self.arn, tagKeys=[key])
+        LOG.info("Removed tag %s from %s", key, self.arn)
+        return True

--- a/src/infrahouse_core/aws/cloudwatch_log_group.py
+++ b/src/infrahouse_core/aws/cloudwatch_log_group.py
@@ -51,6 +51,28 @@ class CloudWatchLogGroup(AWSResource):
         return False
 
     @property
+    def arn(self) -> str:
+        """Return the ARN of the log group.
+
+        Pulled from ``describe_log_groups`` so no account/region plumbing
+        is required at construction time.  The CloudWatch Logs API
+        returns ARNs with a trailing ``:*`` wildcard; this property
+        strips it so the value can be used with ``tag_resource`` and
+        similar APIs that expect a plain resource ARN.
+
+        :raises ValueError: if the log group does not exist.
+        """
+        paginator = self._client.get_paginator("describe_log_groups")
+        for page in paginator.paginate(logGroupNamePrefix=self._resource_id):
+            for group in page.get("logGroups", []):
+                if group["logGroupName"] == self._resource_id:
+                    arn = group["arn"]
+                    if arn.endswith(":*"):
+                        arn = arn[:-2]
+                    return arn
+        raise ValueError(f"Log group {self._resource_id} not found")
+
+    @property
     def retention_in_days(self) -> int | None:
         """Return the retention period in days, or ``None`` if set to never expire."""
         paginator = self._client.get_paginator("describe_log_groups")

--- a/tests/aws/cloudwatch_log_group/test_exists_delete.py
+++ b/tests/aws/cloudwatch_log_group/test_exists_delete.py
@@ -122,6 +122,43 @@ def test_delete_unexpected_error():
         assert exc_info.value.response["Error"]["Code"] == "AccessDeniedException"
 
 
+# -- arn ----------------------------------------------------------------------
+
+
+def test_arn_strips_trailing_wildcard():
+    """arn returns the log group ARN with the trailing :* stripped."""
+    lg = CloudWatchLogGroup(LOG_GROUP_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    api_arn = f"arn:aws:logs:us-east-1:123456789012:log-group:{LOG_GROUP_NAME}:*"
+    mock_client.get_paginator.return_value = _mock_paginator(
+        [{"logGroups": [{"logGroupName": LOG_GROUP_NAME, "arn": api_arn}]}]
+    )
+    with mock.patch.object(CloudWatchLogGroup, "_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        assert lg.arn == f"arn:aws:logs:us-east-1:123456789012:log-group:{LOG_GROUP_NAME}"
+
+
+def test_arn_without_wildcard():
+    """arn returns the ARN unchanged when the API already omits :*."""
+    lg = CloudWatchLogGroup(LOG_GROUP_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    api_arn = f"arn:aws:logs:us-east-1:123456789012:log-group:{LOG_GROUP_NAME}"
+    mock_client.get_paginator.return_value = _mock_paginator(
+        [{"logGroups": [{"logGroupName": LOG_GROUP_NAME, "arn": api_arn}]}]
+    )
+    with mock.patch.object(CloudWatchLogGroup, "_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        assert lg.arn == api_arn
+
+
+def test_arn_not_found():
+    """arn raises ValueError when the log group does not exist."""
+    lg = CloudWatchLogGroup(LOG_GROUP_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_paginator.return_value = _mock_paginator([{"logGroups": []}])
+    with mock.patch.object(CloudWatchLogGroup, "_client", new_callable=mock.PropertyMock, return_value=mock_client):
+        with pytest.raises(ValueError, match="not found"):
+            _ = lg.arn
+
+
 # -- retention_in_days --------------------------------------------------------
 
 

--- a/tests/aws/test_base.py
+++ b/tests/aws/test_base.py
@@ -1,8 +1,39 @@
 """Tests for AWSResource base class."""
 
+from unittest import mock
+
 import pytest
 
 from infrahouse_core.aws.base import AWSResource
+
+TEST_ARN = "arn:aws:logs:us-east-1:123456789012:log-group:/aws/test"
+
+
+class _TaggedResource(AWSResource):
+    """Concrete subclass used to exercise the base tag helpers."""
+
+    @property
+    def exists(self) -> bool:
+        return True
+
+    def delete(self) -> None:
+        pass
+
+    @property
+    def arn(self) -> str:
+        return TEST_ARN
+
+
+def _resource_with_mock_client():
+    resource = _TaggedResource("test", "logs", region="us-east-1")
+    client = mock.MagicMock()
+    patcher = mock.patch.object(
+        _TaggedResource,
+        "_client",
+        new_callable=mock.PropertyMock,
+        return_value=client,
+    )
+    return resource, client, patcher
 
 
 def test_cannot_instantiate():
@@ -35,3 +66,119 @@ def test_complete_subclass():
 
     resource = ConcreteResource("some-id", "ec2", region="us-east-1")
     assert resource.exists is True
+
+
+# -- arn default --------------------------------------------------------------
+
+
+def test_arn_default_not_implemented():
+    """arn raises NotImplementedError unless a subclass implements it."""
+
+    class NoArnResource(AWSResource):
+        @property
+        def exists(self) -> bool:
+            return True
+
+        def delete(self) -> None:
+            pass
+
+    resource = NoArnResource("some-id", "ec2")
+    with pytest.raises(NotImplementedError, match="NoArnResource"):
+        _ = resource.arn
+
+
+# -- tags ---------------------------------------------------------------------
+
+
+def test_tags_returns_mapping():
+    """tags returns the dict from list_tags_for_resource."""
+    resource, client, patcher = _resource_with_mock_client()
+    client.list_tags_for_resource.return_value = {"tags": {"Env": "prod", "Team": "core"}}
+    with patcher:
+        result = resource.tags
+    assert result == {"Env": "prod", "Team": "core"}
+    client.list_tags_for_resource.assert_called_once_with(resourceArn=TEST_ARN)
+
+
+def test_tags_empty_when_missing():
+    """tags returns an empty dict when list_tags_for_resource omits the key."""
+    resource, client, patcher = _resource_with_mock_client()
+    client.list_tags_for_resource.return_value = {}
+    with patcher:
+        assert resource.tags == {}
+
+
+# -- set_tag ------------------------------------------------------------------
+
+
+def test_set_tag_writes_when_absent():
+    """set_tag writes the tag and returns True when the key is absent."""
+    resource, client, patcher = _resource_with_mock_client()
+    client.list_tags_for_resource.return_value = {"tags": {}}
+    with patcher:
+        assert resource.set_tag("Env", "prod") is True
+    client.tag_resource.assert_called_once_with(resourceArn=TEST_ARN, tags={"Env": "prod"})
+
+
+def test_set_tag_writes_when_value_differs():
+    """set_tag overwrites when the existing value differs."""
+    resource, client, patcher = _resource_with_mock_client()
+    client.list_tags_for_resource.return_value = {"tags": {"Env": "dev"}}
+    with patcher:
+        assert resource.set_tag("Env", "prod") is True
+    client.tag_resource.assert_called_once_with(resourceArn=TEST_ARN, tags={"Env": "prod"})
+
+
+def test_set_tag_noop_when_current():
+    """set_tag is a no-op when the tag already has the requested value."""
+    resource, client, patcher = _resource_with_mock_client()
+    client.list_tags_for_resource.return_value = {"tags": {"Env": "prod"}}
+    with patcher:
+        assert resource.set_tag("Env", "prod") is False
+    client.tag_resource.assert_not_called()
+
+
+# -- set_tags -----------------------------------------------------------------
+
+
+def test_set_tags_writes_only_changed():
+    """set_tags writes only the tags whose value differs from current."""
+    resource, client, patcher = _resource_with_mock_client()
+    client.list_tags_for_resource.return_value = {"tags": {"Env": "prod", "Team": "core"}}
+    with patcher:
+        written = resource.set_tags({"Env": "prod", "Team": "platform", "Owner": "ops"})
+    assert written == 2
+    client.tag_resource.assert_called_once_with(
+        resourceArn=TEST_ARN,
+        tags={"Team": "platform", "Owner": "ops"},
+    )
+
+
+def test_set_tags_noop_when_all_current():
+    """set_tags makes no API call when all tags already match."""
+    resource, client, patcher = _resource_with_mock_client()
+    client.list_tags_for_resource.return_value = {"tags": {"Env": "prod"}}
+    with patcher:
+        assert resource.set_tags({"Env": "prod"}) == 0
+    client.tag_resource.assert_not_called()
+
+
+# -- remove_tag ---------------------------------------------------------------
+
+
+def test_remove_tag_when_present():
+    """remove_tag removes the tag and returns True when it was set."""
+    resource, client, patcher = _resource_with_mock_client()
+    client.list_tags_for_resource.return_value = {"tags": {"Env": "prod"}}
+    with patcher:
+        assert resource.remove_tag("Env") is True
+    client.untag_resource.assert_called_once_with(resourceArn=TEST_ARN, tagKeys=["Env"])
+
+
+def test_remove_tag_when_absent():
+    """remove_tag is a no-op when the tag is not set."""
+    resource, client, patcher = _resource_with_mock_client()
+    client.list_tags_for_resource.return_value = {"tags": {}}
+    with patcher:
+        assert resource.remove_tag("Env") is False
+    client.untag_resource.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds `tags` / `set_tag` / `set_tags` / `remove_tag` to `AWSResource` using the generic AWS tag API (`list_tags_for_resource` / `tag_resource` / `untag_resource`), which covers CloudWatch Logs, RDS, Lambda, KMS, Secrets Manager, SNS, SQS, Step Functions and many others. Subclasses with non-generic tag APIs (EC2, S3, IAM) can override.
- Adds `AWSResource.arn` as an opt-in extension point — raises `NotImplementedError` by default so the helpers surface a clear error on subclasses that haven't wired it up yet.
- Implements `CloudWatchLogGroup.arn` by pulling from `describe_log_groups` (issue's option b — no account/region plumbing at construction time), stripping the trailing `:*` wildcard so the value is usable with `tag_resource`.

Caller becomes:
```python
for lg in CloudWatchLogGroup.list_log_groups(prefix=pfx, session=session):
    if lg.set_tag("VantaNoAlert", "true"):
        LOG.info("Tagged %s", lg.log_group_name)
```

All mutators are idempotent — `set_tag`/`set_tags` skip API calls when values already match, `remove_tag` is a no-op when the tag is absent.

Closes #139.

## Test plan
- [x] `make lint` (pylint 10/10)
- [x] `make test` — 571 passed, 2 skipped
- [x] 10 new base-class tag helper tests (write/noop/empty paths, `NotImplementedError` default)
- [x] 3 new `CloudWatchLogGroup.arn` tests (with wildcard, without, not-found)
- [ ] Follow-up: migrate `terraform-aws-org-governance`'s Vanta-tagging code to the new helpers (out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)