### PR TITLE
Override S3Bucket tag methods for S3-native tagging API

### DIFF
--- a/src/infrahouse_core/aws/s3_bucket.py
+++ b/src/infrahouse_core/aws/s3_bucket.py
@@ -112,3 +112,51 @@ class S3Bucket(AWSResource):
 
         if total_deleted:
             LOG.info("Deleted %d object versions from bucket %s", total_deleted, self._resource_id)
+
+    # -- Tag helpers (S3-specific) ----------------------------------------------
+
+    @property
+    def tags(self) -> dict:
+        """Return current tags as a ``{key: value}`` dict."""
+        try:
+            response = self._client.get_bucket_tagging(Bucket=self._resource_id)
+            return {t["Key"]: t["Value"] for t in response.get("TagSet", [])}
+        except ClientError as err:
+            if err.response["Error"]["Code"] == "NoSuchTagSet":
+                return {}
+            raise
+
+    def set_tag(self, key: str, value: str) -> bool:
+        current = self.tags
+        if current.get(key) == value:
+            return False
+        current[key] = value
+        self._put_tags(current)
+        LOG.info("Set tag %s=%s on bucket %s", key, value, self._resource_id)
+        return True
+
+    def set_tags(self, tags: dict) -> int:
+        current = self.tags
+        to_write = {k: v for k, v in tags.items() if current.get(k) != v}
+        if not to_write:
+            return 0
+        current.update(to_write)
+        self._put_tags(current)
+        LOG.info("Set %d tag(s) on bucket %s", len(to_write), self._resource_id)
+        return len(to_write)
+
+    def remove_tag(self, key: str) -> bool:
+        current = self.tags
+        if key not in current:
+            return False
+        del current[key]
+        if current:
+            self._put_tags(current)
+        else:
+            self._client.delete_bucket_tagging(Bucket=self._resource_id)
+        LOG.info("Removed tag %s from bucket %s", key, self._resource_id)
+        return True
+
+    def _put_tags(self, tags: dict) -> None:
+        tag_set = [{"Key": k, "Value": v} for k, v in tags.items()]
+        self._client.put_bucket_tagging(Bucket=self._resource_id, Tagging={"TagSet": tag_set})

--- a/tests/aws/s3_bucket/conftest.py
+++ b/tests/aws/s3_bucket/conftest.py
@@ -1,0 +1,43 @@
+import logging
+import uuid
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+LOG = logging.getLogger()
+
+S3_REGION = "us-west-1"
+
+
+@pytest.fixture
+def s3_bucket():
+    """
+    Create a temporary S3 bucket for integration testing.
+
+    Yields (bucket_name, region) tuple, then deletes the bucket after the test.
+    Skips the test if the current AWS credentials lack the required permissions.
+    """
+    bucket_name = f"ih-core-test-{uuid.uuid4().hex[:8]}"
+    s3 = boto3.client("s3", region_name=S3_REGION)
+
+    try:
+        s3.create_bucket(
+            Bucket=bucket_name,
+            CreateBucketConfiguration={"LocationConstraint": S3_REGION},
+        )
+    except ClientError as exc:
+        error_code = exc.response["Error"]["Code"]
+        if error_code in ("AccessDeniedException", "InvalidClientTokenId"):
+            pytest.skip(f"AWS credentials not usable ({error_code}): {exc}")
+        raise
+
+    s3.get_waiter("bucket_exists").wait(Bucket=bucket_name)
+
+    LOG.info("Created S3 bucket: %s", bucket_name)
+
+    yield bucket_name, S3_REGION
+
+    # Cleanup
+    s3.delete_bucket(Bucket=bucket_name)
+    LOG.info("Deleted S3 bucket: %s", bucket_name)

--- a/tests/aws/s3_bucket/test_tags.py
+++ b/tests/aws/s3_bucket/test_tags.py
@@ -1,0 +1,95 @@
+"""Integration tests for S3Bucket tag operations.
+
+These tests require real AWS credentials and create/delete temporary buckets.
+They are skipped automatically when credentials are not available.
+"""
+
+import os
+
+import pytest
+
+from infrahouse_core.aws.s3_bucket import S3Bucket
+
+_AWS_CREDS = "AWS_ACCESS_KEY_ID" in os.environ and "AWS_SECRET_ACCESS_KEY" in os.environ
+
+
+@pytest.mark.skipif(not _AWS_CREDS, reason="AWS credentials not set in environment")
+def test_tags_empty_bucket(s3_bucket):
+    """A newly created bucket with no tags returns an empty dict."""
+    bucket_name, region = s3_bucket
+    bucket = S3Bucket(bucket_name, region=region)
+    assert bucket.tags == {}
+
+
+@pytest.mark.skipif(not _AWS_CREDS, reason="AWS credentials not set in environment")
+def test_tags_returns_bucket_tags(s3_bucket):
+    """tags returns tags set on the bucket as a flat dict."""
+    import boto3
+
+    bucket_name, region = s3_bucket
+
+    s3 = boto3.client("s3", region_name=region)
+    s3.put_bucket_tagging(
+        Bucket=bucket_name,
+        Tagging={
+            "TagSet": [
+                {"Key": "Environment", "Value": "test"},
+                {"Key": "vanta-exempt", "Value": "true"},
+            ]
+        },
+    )
+
+    bucket = S3Bucket(bucket_name, region=region)
+    tags = bucket.tags
+    assert tags == {"Environment": "test", "vanta-exempt": "true"}
+
+
+@pytest.mark.skipif(not _AWS_CREDS, reason="AWS credentials not set in environment")
+def test_set_tag(s3_bucket):
+    """set_tag writes a single tag to the bucket."""
+    bucket_name, region = s3_bucket
+    bucket = S3Bucket(bucket_name, region=region)
+
+    assert bucket.set_tag("Team", "platform") is True
+    assert bucket.tags["Team"] == "platform"
+
+
+@pytest.mark.skipif(not _AWS_CREDS, reason="AWS credentials not set in environment")
+def test_set_tag_idempotent(s3_bucket):
+    """set_tag returns False when the tag already has the requested value."""
+    bucket_name, region = s3_bucket
+    bucket = S3Bucket(bucket_name, region=region)
+
+    bucket.set_tag("Team", "platform")
+    assert bucket.set_tag("Team", "platform") is False
+
+
+@pytest.mark.skipif(not _AWS_CREDS, reason="AWS credentials not set in environment")
+def test_set_tags(s3_bucket):
+    """set_tags writes multiple tags at once."""
+    bucket_name, region = s3_bucket
+    bucket = S3Bucket(bucket_name, region=region)
+
+    written = bucket.set_tags({"Env": "dev", "Owner": "alice"})
+    assert written == 2
+    assert bucket.tags == {"Env": "dev", "Owner": "alice"}
+
+
+@pytest.mark.skipif(not _AWS_CREDS, reason="AWS credentials not set in environment")
+def test_remove_tag(s3_bucket):
+    """remove_tag deletes a tag from the bucket."""
+    bucket_name, region = s3_bucket
+    bucket = S3Bucket(bucket_name, region=region)
+
+    bucket.set_tag("ToRemove", "yes")
+    assert bucket.remove_tag("ToRemove") is True
+    assert "ToRemove" not in bucket.tags
+
+
+@pytest.mark.skipif(not _AWS_CREDS, reason="AWS credentials not set in environment")
+def test_remove_tag_absent(s3_bucket):
+    """remove_tag returns False when the tag doesn't exist."""
+    bucket_name, region = s3_bucket
+    bucket = S3Bucket(bucket_name, region=region)
+
+    assert bucket.remove_tag("nonexistent") is False

--- a/tests/aws/s3_bucket/test_tags_unit.py
+++ b/tests/aws/s3_bucket/test_tags_unit.py
@@ -1,0 +1,209 @@
+"""Unit tests for S3Bucket tag overrides."""
+
+from unittest import mock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from infrahouse_core.aws.s3_bucket import S3Bucket
+
+BUCKET_NAME = "my-test-bucket"
+
+
+def _make_client_error(code, message="test"):
+    return ClientError({"Error": {"Code": code, "Message": message}}, "test_operation")
+
+
+def _patch_client(mock_client):
+    return mock.patch.object(S3Bucket, "_client", new_callable=mock.PropertyMock, return_value=mock_client)
+
+
+# -- tags property -------------------------------------------------------------
+
+
+def test_tags_returns_flat_dict():
+    bucket = S3Bucket(BUCKET_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_bucket_tagging.return_value = {
+        "TagSet": [
+            {"Key": "Env", "Value": "prod"},
+            {"Key": "Team", "Value": "platform"},
+        ]
+    }
+
+    with _patch_client(mock_client):
+        assert bucket.tags == {"Env": "prod", "Team": "platform"}
+
+    mock_client.get_bucket_tagging.assert_called_once_with(Bucket=BUCKET_NAME)
+
+
+def test_tags_no_tagset_returns_empty():
+    bucket = S3Bucket(BUCKET_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_bucket_tagging.side_effect = _make_client_error("NoSuchTagSet")
+
+    with _patch_client(mock_client):
+        assert bucket.tags == {}
+
+
+def test_tags_unexpected_error_propagates():
+    bucket = S3Bucket(BUCKET_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_bucket_tagging.side_effect = _make_client_error("AccessDenied")
+
+    with _patch_client(mock_client):
+        with pytest.raises(ClientError) as exc_info:
+            _ = bucket.tags
+        assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
+
+
+# -- set_tag -------------------------------------------------------------------
+
+
+def test_set_tag_writes_new_tag():
+    bucket = S3Bucket(BUCKET_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_bucket_tagging.side_effect = _make_client_error("NoSuchTagSet")
+
+    with _patch_client(mock_client):
+        assert bucket.set_tag("Env", "dev") is True
+
+    mock_client.put_bucket_tagging.assert_called_once_with(
+        Bucket=BUCKET_NAME,
+        Tagging={"TagSet": [{"Key": "Env", "Value": "dev"}]},
+    )
+
+
+def test_set_tag_preserves_existing_tags():
+    bucket = S3Bucket(BUCKET_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_bucket_tagging.return_value = {
+        "TagSet": [{"Key": "Existing", "Value": "yes"}]
+    }
+
+    with _patch_client(mock_client):
+        assert bucket.set_tag("New", "val") is True
+
+    call_args = mock_client.put_bucket_tagging.call_args
+    tag_set = call_args.kwargs["Tagging"]["TagSet"]
+    tag_dict = {t["Key"]: t["Value"] for t in tag_set}
+    assert tag_dict == {"Existing": "yes", "New": "val"}
+
+
+def test_set_tag_idempotent():
+    bucket = S3Bucket(BUCKET_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_bucket_tagging.return_value = {
+        "TagSet": [{"Key": "Env", "Value": "prod"}]
+    }
+
+    with _patch_client(mock_client):
+        assert bucket.set_tag("Env", "prod") is False
+
+    mock_client.put_bucket_tagging.assert_not_called()
+
+
+def test_set_tag_overwrites_value():
+    bucket = S3Bucket(BUCKET_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_bucket_tagging.return_value = {
+        "TagSet": [{"Key": "Env", "Value": "dev"}]
+    }
+
+    with _patch_client(mock_client):
+        assert bucket.set_tag("Env", "prod") is True
+
+    call_args = mock_client.put_bucket_tagging.call_args
+    tag_set = call_args.kwargs["Tagging"]["TagSet"]
+    assert tag_set == [{"Key": "Env", "Value": "prod"}]
+
+
+# -- set_tags ------------------------------------------------------------------
+
+
+def test_set_tags_writes_multiple():
+    bucket = S3Bucket(BUCKET_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_bucket_tagging.side_effect = _make_client_error("NoSuchTagSet")
+
+    with _patch_client(mock_client):
+        assert bucket.set_tags({"A": "1", "B": "2"}) == 2
+
+    call_args = mock_client.put_bucket_tagging.call_args
+    tag_set = call_args.kwargs["Tagging"]["TagSet"]
+    tag_dict = {t["Key"]: t["Value"] for t in tag_set}
+    assert tag_dict == {"A": "1", "B": "2"}
+
+
+def test_set_tags_skips_unchanged():
+    bucket = S3Bucket(BUCKET_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_bucket_tagging.return_value = {
+        "TagSet": [{"Key": "A", "Value": "1"}, {"Key": "B", "Value": "2"}]
+    }
+
+    with _patch_client(mock_client):
+        assert bucket.set_tags({"A": "1", "B": "2"}) == 0
+
+    mock_client.put_bucket_tagging.assert_not_called()
+
+
+def test_set_tags_partial_update():
+    bucket = S3Bucket(BUCKET_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_bucket_tagging.return_value = {
+        "TagSet": [{"Key": "A", "Value": "1"}, {"Key": "B", "Value": "old"}]
+    }
+
+    with _patch_client(mock_client):
+        assert bucket.set_tags({"A": "1", "B": "new", "C": "3"}) == 2
+
+    call_args = mock_client.put_bucket_tagging.call_args
+    tag_set = call_args.kwargs["Tagging"]["TagSet"]
+    tag_dict = {t["Key"]: t["Value"] for t in tag_set}
+    assert tag_dict == {"A": "1", "B": "new", "C": "3"}
+
+
+# -- remove_tag ----------------------------------------------------------------
+
+
+def test_remove_tag_deletes():
+    bucket = S3Bucket(BUCKET_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_bucket_tagging.return_value = {
+        "TagSet": [{"Key": "Env", "Value": "dev"}, {"Key": "Team", "Value": "x"}]
+    }
+
+    with _patch_client(mock_client):
+        assert bucket.remove_tag("Env") is True
+
+    call_args = mock_client.put_bucket_tagging.call_args
+    tag_set = call_args.kwargs["Tagging"]["TagSet"]
+    assert tag_set == [{"Key": "Team", "Value": "x"}]
+    mock_client.delete_bucket_tagging.assert_not_called()
+
+
+def test_remove_last_tag_deletes_tagging():
+    bucket = S3Bucket(BUCKET_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_bucket_tagging.return_value = {
+        "TagSet": [{"Key": "Only", "Value": "one"}]
+    }
+
+    with _patch_client(mock_client):
+        assert bucket.remove_tag("Only") is True
+
+    mock_client.put_bucket_tagging.assert_not_called()
+    mock_client.delete_bucket_tagging.assert_called_once_with(Bucket=BUCKET_NAME)
+
+
+def test_remove_tag_absent():
+    bucket = S3Bucket(BUCKET_NAME, region="us-east-1")
+    mock_client = mock.MagicMock()
+    mock_client.get_bucket_tagging.side_effect = _make_client_error("NoSuchTagSet")
+
+    with _patch_client(mock_client):
+        assert bucket.remove_tag("nope") is False
+
+    mock_client.put_bucket_tagging.assert_not_called()
+    mock_client.delete_bucket_tagging.assert_not_called()


### PR DESCRIPTION
## Summary
- Override `tags`, `set_tag`, `set_tags`, and `remove_tag` in `S3Bucket` to use `get_bucket_tagging` / `put_bucket_tagging` / `delete_bucket_tagging` instead of the generic `list_tags_for_resource` API that S3 doesn't support.
- Handle `NoSuchTagSet` error (returned for untagged buckets) by returning an empty dict.
- When removing the last tag, use `delete_bucket_tagging` instead of `put_bucket_tagging` with an empty `TagSet`.

## Test plan
- [x] 13 unit tests (`test_tags_unit.py`) covering all tag methods, idempotency, error propagation, and edge cases
- [x] 7 integration tests (`test_tags.py`) that create real S3 buckets when `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` are set
- [x] Full test suite passes (584 passed, 9 skipped)
- [x] pylint 10/10

Fixes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)